### PR TITLE
feat(blog): Add new blog post about configuring Python version in pyproject.toml

### DIFF
--- a/content/blog/how-to-configure-a-minimum-python-version-in-pyprojecttoml/contents.lr
+++ b/content/blog/how-to-configure-a-minimum-python-version-in-pyprojecttoml/contents.lr
@@ -53,3 +53,5 @@ pythontips
 llamabot
 ---
 twitter_handle: ericmjl
+---
+pub_date: 2023-07-12

--- a/content/blog/how-to-configure-a-minimum-python-version-in-pyprojecttoml/contents.lr
+++ b/content/blog/how-to-configure-a-minimum-python-version-in-pyprojecttoml/contents.lr
@@ -1,0 +1,55 @@
+title: How to configure a minimum Python version in pyproject.toml
+---
+author: Eric J. Ma
+---
+body:
+
+Today, I learned how to set the minimum version of Python in `pyproject.toml`.
+
+If I want a minimum version of Python:
+
+```text
+[project]
+python = ">=3.10"
+```
+
+If I want a maximum version of Python:
+
+```text
+[project]
+python = "<=3.10"
+```
+
+This problem came up within the context of `llamabot`, where I was using relatively new syntax to indicate the union of types:
+
+```python
+doc_paths: List[str] | List[Path] | str | Path = None
+```
+
+Pre-Python 3.10, the only way to show this was:
+
+```python
+doc_paths: Union[List[str], List[Path], str, Path] = None
+```
+
+Visually, I think the post-Python 3.10 syntax is a bit easier to reason about.
+
+h/t my colleague Jiayi Cox who helped me identify the bug in [this issue](https://github.com/ericmjl/llamabot/issues/3).
+---
+summary:
+
+In today's blog post, we dive into setting the minimum and maximum Python versions in `pyproject.toml` 🐍.
+We explore how this impacts `llamabot` and discuss the new syntax for indicating the union of types in Python 3.10.
+This new syntax is visually easier to understand, making our coding journey a bit smoother! 🚀👩‍💻👨‍💻
+---
+tags:
+
+til
+python
+python310
+pythonversioning
+pyproject.toml
+pythontips
+llamabot
+---
+twitter_handle: ericmjl


### PR DESCRIPTION
This PR introduces a new blog post that explains 
how to set the minimum and maximum Python versions in `pyproject.toml`. 
The post also discusses the impact of this configuration on `llamabot` 
and the new syntax for indicating the union of types in Python 3.10. 
The new syntax is visually easier to understand, which can make coding more efficient.