### PR TITLE
feat(blog): Add new blog post on service vs product-oriented data science

### DIFF
--- a/content/blog/service-vs-product-oriented-data-science/contents.lr
+++ b/content/blog/service-vs-product-oriented-data-science/contents.lr
@@ -4,43 +4,104 @@ author: Eric J. Ma
 ---
 body:
 
-As the field of data science progresses and evolves within the biotech space, I'm seeing two flavours of data science work showing up.
+As the field of data science progresses and evolves within the biotech space,
+I'm seeing two flavours of data science work showing up.
 
-The first is service-oriented data science. The second is product-oriented data science.
+The first is service-oriented data science.
+The second is product-oriented data science.
 
 These two can be conceived along a continuum.
 
 ## What is service-oriented data science?
 
-As its name suggests, this flavor of data science is all about _serving_ others, mostly in a one-off fashion. In this flavor of data science, the _insights_ derived from a model-building effort are the object of value. Examples of this kind of data science might be building a mechanistic model of an biophysical measurement in order to quantify some key parameter of interest (e.g. half-life decay, or thermal stability), which can be used downstream. In this mode, we encounter a wide range of problems, and our impact is primarily on the individual or group that is being serviced.
+As its name suggests,
+this flavour of data science is all about _serving_ others,
+mainly in a one-off fashion.
+In this flavour of data science,
+the _insights_ derived from a model-building effort are the object of value.
+Examples of this kind of data science might be building a mechanistic model of a biophysical measurement to quantify some key parameter of interest (e.g., half-life decay or thermal stability),
+which can be used downstream.
+In this mode,
+we encounter a wide range of problems,
+and our impact is primarily on the individual or group being serviced.
 
 ## What about product-oriented data science?
 
-As its name suggests, this flavor of data science is all about _building a product_ that can serve users over and over on a narrowly-defined but valuable problem. Examples of this kind of data science might be building a predictive model of protein stability, or a mutation sampler from evolutionary sequences, that one can use over and over again in future protein engineering campaigns. In this mode, we are building a reusable tool that solves a well-defined problem, effectively expanding our colleagues' capabilities in a scalable fashion.
+As its name suggests,
+this flavour of data science is all about _building a product_ that can serve users over and over on a narrowly defined but valuable problem.
+Examples of this kind of data science might be building a predictive model of protein stability or a mutation sampler from evolutionary sequences that one can use repeatedly in future protein engineering campaigns.
+In this mode,
+we are building a reusable tool that solves a well-defined problem,
+effectively expanding our colleagues' capabilities in a scalable fashion.
 
-(h/t to Andrew Giessel and Dave Johnson, from whom I first heard this concept articulated.)
+(h/t to Andrew Giessel and Dave Johnson,
+from whom I first heard this concept articulated.)
 
-In both cases, the model itself is not of as much value as the capabilities it enables or the insights it delivers.
+In both cases,
+the model itself is of less value than the capabilities it enables or the insights it delivers.
 
 ## Is one mode more valuable than another?
 
 My answer is yes... depending on the situation.
 
-How do we know which? I've identified two plausible scenarios, one for each mode.
+How do we know which?
+I've identified two plausible scenarios,
+one for each mode.
 
-When one's broader organization is in a position where people need convincing of the value of a methodology, a service-oriented posture is necessary. On the other hand, when one's organization is in need of automation that cannot be accomplished by simply chaining off-the-shelf tools together, then a product-oriented posture is going to be necessary.
+When one's broader organization is in a position where people need convincing of the value of a methodology,
+a service-oriented posture is necessary.
+On the other hand,
+when one's organization needs automation that cannot be accomplished by simply chaining off-the-shelf tools together,
+then a product-oriented posture will be necessary.
 
-Even within a team project, I find that one can switch between service- and product-orientations. In service of the project's goals, we can adopt a service-oriented posture and help deliver insights, library designs, or more. But behind-the-scenes, we can adopt a more product-oriented posture and build out reusable tools and components for the general class of problem being solved.
+Even within a team project,
+one can switch between service- and product-orientations.
+In favour of the project's goals,
+we can adopt a service-oriented posture and help deliver insights,
+library designs,
+or more.
+But behind the scenes,
+we can adopt a more product-oriented stance and build out reusable tools and components for the general class of problems being solved.
 
-## What challenges are there navigating the spectrum?
+## What challenges are there in navigating the spectrum?
 
-Our collaborators will always care about being served first. The "how", on the other hand, doesn't really matter as much, whether it is through white-glove service or through a tool that we build for them.
+Our collaborators will always care about being served first.
+The "how",
+on the other hand,
+doesn't really matter as much,
+whether through white-glove service or through a tool we build for them.
 
-In that respect, it can be tempting to adopt a service-oriented posture when building a tool may be of a higher ROI. An example of a very challenging instance of this problem, which I've seen before, is the situation where my teammates were asked to design a protein library using rules similar to a previously designed one, but with minor differences for a new protein. This ask precludes _blindly_ re-running code for generating protein libraries; instead, modifications are needed. Here, a product-oriented service posture (yes, I did just chain those four words together) can be beneficial. With simple and good software engineering practices, [which necessarily means thinking clearly about our work](https://ericmjl.github.io/blog/2020/8/21/software-engineering-as-a-research-practice/index.html), we can make the routine things easy while incorporating the new and varied things modularly.
+In that respect,
+it is tempting to adopt a service-oriented posture when building a higher ROI tool.
+An example of a very challenging instance of this problem I've seen before is when my teammates were asked to design a protein library using rules similar to a previously designed one but with minor differences for a new protein.
+This ask precludes _blindly_ re-running code for generating protein libraries;
+instead,
+modifications are needed.
+Here,
+a product-oriented service posture (yes, I did chain those four words together) can be beneficial.
+With simple and good software engineering practices,
+[which necessarily means thinking clearly about our work](https://ericmjl.github.io/blog/2020/8/21/software-engineering-as-a-research-practice/index.html),
+we can make routine things easy while incorporating the new and varied things modularly.
 
-On the other hand, if one adopts a product-oriented posture, the challenge there lies in one becoming progressively detached from our collaborators for whom our products are supposed to serve. In this situation, it can be tempting to delve into a problem for an extended period of time, tinkering in circles without the necessary feedback from our collaborators on whether our product solves their pain points. Thankfully, my teammates and I have not yet found ourselves in this situation. One of the ways we stay vigilant here is by constantly asking ourselves the core question, "Does this serve our collaborators?"
+On the other hand,
+if one adopts a product-oriented posture,
+the challenge lies in becoming progressively detached from the collaborators our products are supposed to serve.
+In this situation,
+it can be tempting to delve into a problem for an extended period,
+tinkering in circles without the necessary feedback from our collaborators on whether our product solves their pain points.
+Thankfully,
+my teammates and I have not yet been in this situation.
+One of the ways we stay vigilant here is by constantly asking ourselves the core question,
+"Does this serve our collaborators?"
 
-In general, I prefer that my teammates and I adopt a product-first orientation, building tools with high leverage, while using a service-first orientation to help demonstrate the value of those tools that we build. For some, this is a challenge: if one's instinct is to "just solve the problem" without stepping back to think of the general case of the problem, then one ends up in a _habitual_ service orientation, which I consider to be of extremely low leverage.
+In general,
+I prefer that my teammates and I adopt a product-first orientation,
+building tools with high leverage while using a service-first orientation to help demonstrate the value of those tools that we build.
+For some,
+this is a challenge:
+if one's instinct is to "just solve the problem" without stepping back to think of the general case of the problem,
+then one ends up in a _habitual_ service orientation,
+which I consider to be of extremely low leverage.
 ---
 pub_date: 2023-08-28
 ---

--- a/content/blog/service-vs-product-oriented-data-science/contents.lr
+++ b/content/blog/service-vs-product-oriented-data-science/contents.lr
@@ -94,6 +94,8 @@ my teammates and I have not yet been in this situation.
 One of the ways we stay vigilant here is by constantly asking ourselves the core question,
 "Does this serve our collaborators?"
 
+## What can I do as an individual contributor or team lead?
+
 In general,
 I prefer that my teammates and I adopt a product-first orientation,
 building tools with high leverage while using a service-first orientation to help demonstrate the value of those tools that we build.
@@ -102,21 +104,42 @@ this is a challenge:
 if one's instinct is to "just solve the problem" without stepping back to think of the general case of the problem,
 then one ends up in a _habitual_ service orientation,
 which I consider to be of extremely low leverage.
+
+For an individual contributor, then,
+I think a mindset shift is necessary.
+Rather than being mere _consumers_ of tooling,
+one needs to become a _maker_ of tools as well.
+Being able to make tools for oneself is a data science superpower that will differentiate one from the pack.
+This is in-line with [knowing every last detail of your computational stack](https://ericmjl.github.io/data-science-bootstrap-notes/data-scientists-should-strive-to-know-every-last-detail-about-their-compute-stack/),
+and being able to build parts of that stack yourself will give you much more agency and freedom.
+
+For a team lead, one needs to make time and space for your teammates to be able to build stuff -
+reusable components that improve the efficiency of one's work,
+and reusable tooling that allow a collaborator's work to scale.
+Sometimes, this may entail saying "no" to requests from collaborators
+in order to dedicate time to internal builds.
+Buffer time needs to be added into estimates of when something can be delivered
+in order to allow for this kind of work.
 ---
 pub_date: 2023-08-28
 ---
 twitter_handle: ericmjl
 ---
-summary: In this blog post, I explore the two flavors of data science work in biotech: service-oriented and product-oriented. Service-oriented data science serves others in a one-off fashion, providing valuable insights. Product-oriented data science, on the other hand, builds reusable tools for a well-defined problem. Both have their value and challenges, and the choice between them depends on the situation. I advocate for a product-first orientation, using service-first to demonstrate the value of the tools we build.
+summary: In this blog post, I explore the two flavours of data science work: service-oriented and product-oriented. Service-oriented data science serves others in a one-off fashion, while product-oriented data science builds a reusable tool for a well-defined problem. Both have their value depending on the situation. I discuss the challenges in navigating between the two and emphasize the importance of adopting a product-first orientation. As an individual contributor or team lead, it's crucial to shift from being mere consumers of tooling to makers of tools, enhancing efficiency and scalability!
 ---
 tags:
 
-data science
-biotech
-data insights
-product oriented
-predictive models
-protein engineering
 automation
-team collaboration
+biotech
+collaboration
+data insights
+data product
+data science
+model building
+predictive models
+product oriented
+protein engineering
+service oriented
 software engineering
+team collaboration
+tool building

--- a/content/blog/service-vs-product-oriented-data-science/contents.lr
+++ b/content/blog/service-vs-product-oriented-data-science/contents.lr
@@ -1,0 +1,61 @@
+title: Service vs. Product-Oriented Data Science
+---
+author: Eric J. Ma
+---
+body:
+
+As the field of data science progresses and evolves within the biotech space, I'm seeing two flavours of data science work showing up.
+
+The first is service-oriented data science. The second is product-oriented data science.
+
+These two can be conceived along a continuum.
+
+## What is service-oriented data science?
+
+As its name suggests, this flavor of data science is all about _serving_ others, mostly in a one-off fashion. In this flavor of data science, the _insights_ derived from a model-building effort are the object of value. Examples of this kind of data science might be building a mechanistic model of an biophysical measurement in order to quantify some key parameter of interest (e.g. half-life decay, or thermal stability), which can be used downstream. In this mode, we encounter a wide range of problems, and our impact is primarily on the individual or group that is being serviced.
+
+## What about product-oriented data science?
+
+As its name suggests, this flavor of data science is all about _building a product_ that can serve users over and over on a narrowly-defined but valuable problem. Examples of this kind of data science might be building a predictive model of protein stability, or a mutation sampler from evolutionary sequences, that one can use over and over again in future protein engineering campaigns. In this mode, we are building a reusable tool that solves a well-defined problem, effectively expanding our colleagues' capabilities in a scalable fashion.
+
+(h/t to Andrew Giessel and Dave Johnson, from whom I first heard this concept articulated.)
+
+In both cases, the model itself is not of as much value as the capabilities it enables or the insights it delivers.
+
+## Is one mode more valuable than another?
+
+My answer is yes... depending on the situation.
+
+How do we know which? I've identified two plausible scenarios, one for each mode.
+
+When one's broader organization is in a position where people need convincing of the value of a methodology, a service-oriented posture is necessary. On the other hand, when one's organization is in need of automation that cannot be accomplished by simply chaining off-the-shelf tools together, then a product-oriented posture is going to be necessary.
+
+Even within a team project, I find that one can switch between service- and product-orientations. In service of the project's goals, we can adopt a service-oriented posture and help deliver insights, library designs, or more. But behind-the-scenes, we can adopt a more product-oriented posture and build out reusable tools and components for the general class of problem being solved.
+
+## What challenges are there navigating the spectrum?
+
+Our collaborators will always care about being served first. The "how", on the other hand, doesn't really matter as much, whether it is through white-glove service or through a tool that we build for them.
+
+In that respect, it can be tempting to adopt a service-oriented posture when building a tool may be of a higher ROI. An example of a very challenging instance of this problem, which I've seen before, is the situation where my teammates were asked to design a protein library using rules similar to a previously designed one, but with minor differences for a new protein. This ask precludes _blindly_ re-running code for generating protein libraries; instead, modifications are needed. Here, a product-oriented service posture (yes, I did just chain those four words together) can be beneficial. With simple and good software engineering practices, [which necessarily means thinking clearly about our work](https://ericmjl.github.io/blog/2020/8/21/software-engineering-as-a-research-practice/index.html), we can make the routine things easy while incorporating the new and varied things modularly.
+
+On the other hand, if one adopts a product-oriented posture, the challenge there lies in one becoming progressively detached from our collaborators for whom our products are supposed to serve. In this situation, it can be tempting to delve into a problem for an extended period of time, tinkering in circles without the necessary feedback from our collaborators on whether our product solves their pain points. Thankfully, my teammates and I have not yet found ourselves in this situation. One of the ways we stay vigilant here is by constantly asking ourselves the core question, "Does this serve our collaborators?"
+
+In general, I prefer that my teammates and I adopt a product-first orientation, building tools with high leverage, while using a service-first orientation to help demonstrate the value of those tools that we build. For some, this is a challenge: if one's instinct is to "just solve the problem" without stepping back to think of the general case of the problem, then one ends up in a _habitual_ service orientation, which I consider to be of extremely low leverage.
+---
+pub_date: 2023-08-28
+---
+twitter_handle: ericmjl
+---
+summary: In this blog post, I explore the two flavors of data science work in biotech: service-oriented and product-oriented. Service-oriented data science serves others in a one-off fashion, providing valuable insights. Product-oriented data science, on the other hand, builds reusable tools for a well-defined problem. Both have their value and challenges, and the choice between them depends on the situation. I advocate for a product-first orientation, using service-first to demonstrate the value of the tools we build.
+---
+tags:
+
+data science
+biotech
+data insights
+product oriented
+predictive models
+protein engineering
+automation
+team collaboration
+software engineering


### PR DESCRIPTION
This commit introduces a new blog post titled "Service vs. Product-Oriented Data Science". The post explores the two flavors of data science work in biotech: service-oriented and product-oriented. It discusses their value, challenges, and the choice between them depending on the situation. The author advocates for a product-first orientation, using service-first to demonstrate the value of the tools we build.

/schedule 2023-09-02