### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
 
       # https://github.com/actions/setup-python
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.10"
 
@@ -31,7 +31,7 @@ jobs:
 
       # https://github.com/actions/cache
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4.0.2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -47,7 +47,7 @@ jobs:
 
       # https://github.com/peaceiris/actions-gh-pages
       - name: Deploy website to ericmjl.github.io
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           # https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-personal-access-token-personal_token
           personal_token: ${{ secrets.GHPAGES_TOKEN }}

--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -14,7 +14,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v2
+      - uses: gr2m/merge-schedule-action@v2.4.3
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.9"
 
@@ -26,7 +26,7 @@ jobs:
 
       # Taken from: https://github.com/drivendataorg/cloudpathlib/blob/master/.github/workflows/docs-preview.yml
       - name: Deploy site preview to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v3.0.0
         with:
           publish-dir: "./site"
           production-deploy: false

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action)** published a new release **[v2.4.3](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.4.3)** on 2024-01-28T17:26:56Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[nwtgck/actions-netlify](https://github.com/nwtgck/actions-netlify)** published a new release **[v3.0.0](https://github.com/nwtgck/actions-netlify/releases/tag/v3.0.0)** on 2024-03-10T02:11:38Z
* **[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)** published a new release **[v4.0.0](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.0.0)** on 2024-04-08T15:43:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.2.0](https://github.com/actions/setup-python/releases/tag/v5.2.0)** on 2024-08-29T13:57:38Z
