### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
 
 
       # setup pixi

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - name: Setup Python
         uses: actions/setup-python@v5.2.0
         with:

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
