### PR TITLE
ci(preview-website)👷: Update GitHub Actions workflow for PR previews

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -31,3 +31,4 @@ jobs:
         uses: rossjrw/pr-preview-action@v1.4.8
         with:
           source-dir: ./site
+          force: true

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -27,6 +27,9 @@ jobs:
           pixi install
           pixi run build
 
+      - name: Remove large files
+        run: rm pr-preview/pr-124/.lektor/buildstate
+
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1.4.8
         with:

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -2,6 +2,11 @@ name: Preview Website
 
 on: [pull_request]
 
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,19 +27,7 @@ jobs:
           pixi install
           pixi run build
 
-      # Taken from: https://github.com/drivendataorg/cloudpathlib/blob/master/.github/workflows/docs-preview.yml
-      - name: Deploy site preview to Netlify
-        uses: nwtgck/actions-netlify@v3.0.0
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1.4.8
         with:
-          publish-dir: "./site"
-          production-deploy: false
-          github-token: ${{ secrets.GHPAGES_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
-          enable-commit-comment: false
-          overwrites-pull-request-comment: true
-          alias: deploy-preview-${{ github.event.number }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 10
+          source-dir: ./site


### PR DESCRIPTION
- Add concurrency settings to cancel in-progress jobs when new commits are pushed.
- Change deployment action to use rossjrw/pr-preview-action@v1.4.8.
- Simplify deployment configuration by specifying only the source directory.