### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -14,7 +14,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v2.4.4
+      - uses: gr2m/merge-schedule-action@v2.5.0
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action)** published a new release **[v2.5.0](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.5.0)** on 2024-11-26T18:44:47Z
