### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -16,7 +16,7 @@ jobs:
 
 
       # setup pixi
-      - uses: prefix-dev/setup-pixi@v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.2
         with:
           pixi-version: v0.30.0
           cache: true

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.8.2
         with:
           pixi-version: v0.28.0
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi)** published a new release **[v0.8.2](https://github.com/prefix-dev/setup-pixi/releases/tag/v0.8.2)** on 2025-02-11T15:59:56Z
