### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -14,7 +14,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v2.6.0
+      - uses: gr2m/merge-schedule-action@v2.6.1
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action)** published a new release **[v2.6.1](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.6.1)** on 2025-02-21T20:26:33Z
