### PR TITLE
chore(ci)🔧: Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
- Set up Dependabot to check for updates to GitHub Actions on a weekly basis.