### PR TITLE
feat(user-manual)📖: Add user manual page and navigation link

### DIFF
--- a/content/user-manual/contents.lr
+++ b/content/user-manual/contents.lr
@@ -6,13 +6,9 @@ body:
 
 *A guide to working well with me. Inspired by [Jason Liu](https://jxnl.co/user_manual/).*
 
-----
-
 ## Read me to work well with me
 
 This is a short guide to how I operate and how we can work well together. Consider it a set of default assumptions to help you navigate working with me. If anything feels off or doesn’t work for you, let’s talk.
-
-----
 
 ## What you can expect from me
 
@@ -27,8 +23,6 @@ You’ll have room to explore your own ideas. Sometimes I’ll let you repeat pa
 
 **I value thoughtfulness.**
 I appreciate intentionality — in code, in communication, and in how we spend time. Fast is good, but deliberate is better.
-
-----
 
 ## What I expect from you
 
@@ -47,8 +41,6 @@ Find a few people inside or outside your team whose feedback you trust and whose
 **Interview externally once a year.**
 It’s a healthy habit. For everyone, it helps keep your interviewing muscle strong and gives you a clearer view of the industry. If you’re working directly with me and I’m your line manager, feel free to share — it gives me a sense of your ambitions. I treat it as data, not disloyalty.
 
-----
-
 ## My quirks
 
 **I think in outlines.**
@@ -59,8 +51,6 @@ I love fast loops and tight cycles. I also value stepping back to think through 
 
 **I admire useful craft.**
 If you show me a better way to do something (especially something repeatable), I’ll probably adopt it — and remember that you taught me.
-
-----
 
 ## If you're junior and seeking advice
 
@@ -73,8 +63,6 @@ I want our conversation to be worth your while. Bring your real challenges, unce
 **Take what inspires.**
 Not everything I say will apply directly to your situation. That’s okay. I often speak from experience, and sometimes it’s just meant to spark ideas. Inspiration matters. The more sources you draw from, the more creative your thinking can become.
 
-----
-
 ## My beliefs about tools and AI
 
 **Use AI where it helps you move faster or think better.**
@@ -83,6 +71,6 @@ You don’t need permission. AI can be an extension of your brain — a fast, ti
 **AI-generated meeting prep is great.**
 If AI helps you organize your thoughts and clearly articulate what you're thinking — especially for meetings or check-ins — go for it. I welcome written-down thoughts ahead of time, even if they're transcribed or structured with AI. If that makes you more effective, I’m all for it.
 
-----
+## Postface
 
 Let’s build something great together :)

--- a/content/user-manual/contents.lr
+++ b/content/user-manual/contents.lr
@@ -1,0 +1,88 @@
+_model: page
+---
+title: User Manual
+---
+body:
+
+*A guide to working well with me. Inspired by [Jason Liu](https://jxnl.co/user_manual/).*
+
+----
+
+## Read me to work well with me
+
+This is a short guide to how I operate and how we can work well together. Consider it a set of default assumptions to help you navigate working with me. If anything feels off or doesn’t work for you, let’s talk.
+
+----
+
+## What you can expect from me
+
+**I don’t like exercising power.**
+I’ll rarely invoke authority. I prefer to convince through reason. When I push strongly, it’s usually because I believe the cost of inaction is high.
+
+**I care about clarity and momentum.**
+I try to help maintain clear priorities, reduce friction, and ship valuable work regularly.
+
+**I believe in autonomy and learning.**
+You’ll have room to explore your own ideas. Sometimes I’ll let you repeat paths I’ve taken if I think there’s value in learning them firsthand. If there’s a rabbit hole, I’ll warn you about it. I won’t stop you from exploring it, but I’ll value it even more if you take the warning seriously and learn from my experience before going down that path. New missteps are encouraged. Repeated ones are annoying — I’ll call them out.
+
+**I value thoughtfulness.**
+I appreciate intentionality — in code, in communication, and in how we spend time. Fast is good, but deliberate is better.
+
+----
+
+## What I expect from you
+
+**Own your craft.**
+Whether you’re junior or senior, I expect you to take pride in your work and keep learning. Stay sharp. Competency and curiosity are baseline.
+
+**Ship things that matter. Shipping things matters.**
+You don’t need to wait for perfection. Shipping regularly builds trust, generates feedback, and accelerates learning. I care that we ship stuff out to our customers and collaborators. And I care that what we ship matters.
+
+**Master micro-efficiencies.**
+Keyboard shortcuts. Smart tooling. Command-line magic. These things compound. They make you faster and earn you respect.
+
+**Cultivate your network.**
+Find a few people inside or outside your team whose feedback you trust and whose knowledge you can draw from. Learning doesn’t have to be top-down.
+
+**Interview externally once a year.**
+It’s a healthy habit. For everyone, it helps keep your interviewing muscle strong and gives you a clearer view of the industry. If you’re working directly with me and I’m your line manager, feel free to share — it gives me a sense of your ambitions. I treat it as data, not disloyalty.
+
+----
+
+## My quirks
+
+**I think in outlines.**
+Structure helps me process faster. Clearly articulated thoughts matter most. If you’re prepping for a meeting with me, consider sending your thoughts written down ahead-of-time. That helps me help you.
+
+**I like efficiency, but not at the cost of care.**
+I love fast loops and tight cycles. I also value stepping back to think through edge cases, consequences, and tradeoffs.
+
+**I admire useful craft.**
+If you show me a better way to do something (especially something repeatable), I’ll probably adopt it — and remember that you taught me.
+
+----
+
+## If you're junior and seeking advice
+
+**Come prepared.**
+If you're looking for guidance or mentorship, I deeply appreciate when you've thought through your questions in advance. Preparation signals intentionality and helps us make the most of our time together.
+
+**Aim for value.**
+I want our conversation to be worth your while. Bring your real challenges, uncertainties, or opportunities. I’ll do my best to offer insight — or help you discover it.
+
+**Take what inspires.**
+Not everything I say will apply directly to your situation. That’s okay. I often speak from experience, and sometimes it’s just meant to spark ideas. Inspiration matters. The more sources you draw from, the more creative your thinking can become.
+
+----
+
+## My beliefs about tools and AI
+
+**Use AI where it helps you move faster or think better.**
+You don’t need permission. AI can be an extension of your brain — a fast, tireless assistant. Use it well.
+
+**AI-generated meeting prep is great.**
+If AI helps you organize your thoughts and clearly articulate what you're thinking — especially for meetings or check-ins — go for it. I welcome written-down thoughts ahead of time, even if they're transcribed or structured with AI. If that makes you more effective, I’m all for it.
+
+----
+
+Let’s build something great together :)

--- a/databags/nav.json
+++ b/databags/nav.json
@@ -36,6 +36,11 @@
             "icon": "fa-university"
         },
         {
+            "title": "User Manual",
+            "href": "/user-manual",
+            "icon": "fa-book"
+        },
+        {
             "title": "Bio",
             "href": "/bio",
             "icon": "fa-user"


### PR DESCRIPTION
- Create a new user manual page at /user-manual with guidelines and expectations.
- Add 'User Manual' entry to the site navigation with a book icon.