### PR TITLE
Fix typos: NVIDIA cuCIM, not QSYN; Chili Thai, not Chilli Thai

### DIFF
--- a/content/blog/reflections-on-the-scipy-2025-conference/contents.lr
+++ b/content/blog/reflections-on-the-scipy-2025-conference/contents.lr
@@ -62,7 +62,7 @@ Key improvements include a single consistent API where distributions are classes
 
 ### High-Level API Dispatching for Community Scaling (Erik Welch)
 
-This presentation explored how dispatching enables scaling of open source communities while managing contributor burden. The speaker shared implementation experiences with NetworkX (3-year evolution from pure Python to supporting faster implementations) and Scikit-Image (1-year implementation dispatching to NVIDIA QSYN).
+This presentation explored how dispatching enables scaling of open source communities while managing contributor burden. The speaker shared implementation experiences with NetworkX (3-year evolution from pure Python to supporting faster implementations) and Scikit-Image (1-year implementation dispatching to NVIDIA cuCIM).
 
 The talk emphasized community engagement importance, careful bandwidth management, and maintaining balance between users, library maintainers, and backend developers. While dispatching is "deceptively simple," it requires careful consideration of nuanced implementation choices.
 
@@ -118,7 +118,7 @@ Using the same approach from my Data-Driven Pharma talk, I showed them how I can
 
 A few smaller moments that captured the spirit of SciPy and the power of modern notebook sharing: I helped Hugo with a quick analysis during the conference and was able to simply airdrop him a Marimo notebook with the complete analysis. The fact that I could share a fully self-contained, executable analysis so seamlessly really demonstrated how far we've come in making scientific computing more collaborative and accessible.
 
-Another remarkable tidbit: I went to Chilli Thai for the sixth and seventh time in two years, which is pretty remarkable considering that I've only been at the conference for a total of 14 days. Chilli Thai really earns high ratings from me - the duck curry and the panang curry are amongst the best I've ever had.
+Another remarkable tidbit: I went to Chili Thai for the sixth and seventh time in two years, which is pretty remarkable considering that I've only been at the conference for a total of 14 days. Chili Thai really earns high ratings from me - the duck curry and the panang curry are amongst the best I've ever had.
 
 ## Conclusion
 


### PR DESCRIPTION
Nice blog post!

[cuCIM](https://docs.rapids.ai/api/cucim/stable/) is NVIDIA's scikit-image-like library for image processing (it is admittedly a weird name; the "C" is for "Clara" for historical reasons).

Also, [Chili Thai](https://www.google.com/maps/place/Chili+Thai+Downtown+Tacoma/@47.2521494,-122.4398196,16z/data=!4m15!1m8!3m7!1s0x5490550fba308829:0xbaa9519159a6f938!2sChili+Thai+Downtown+Tacoma!8m2!3d47.252204!4d-122.4394794!10e5!16s%2Fg%2F11stz0w7jh!3m5!1s0x5490550fba308829:0xbaa9519159a6f938!8m2!3d47.252204!4d-122.4394794!16s%2Fg%2F11stz0w7jh?authuser=0&hl=en&entry=ttu&g_ep=EgoyMDI1MDcyNy4wIKXMDSoASAFQAw%3D%3D) (not Chilli) was so good I took another group of people there!