### PR TITLE
Fix typo on latest blog ("node", not "note")

### DIFF
--- a/content/blog/from-nerd-sniped-to-shipped-using-ai-as-a-thinking-tool/contents.lr
+++ b/content/blog/from-nerd-sniped-to-shipped-using-ai-as-a-thinking-tool/contents.lr
@@ -46,7 +46,7 @@ The major breakthrough came when I scrutinized the design and asked: why do we h
 
 The natural follow-up hit me: lists are just linear graphs, so why do I need two separate structures? I can just have one that defaults to a linear graph, and then use an LLM for intelligent node selection in the threaded case.
 
-So I generalized everything to use NetworkX graphs underneath, with intelligent note selection for threaded memory. This single insight simplified the entire architecture.
+So I generalized everything to use NetworkX graphs underneath, with intelligent node selection for threaded memory. This single insight simplified the entire architecture.
 
 This is exactly what I mean about earning your automation - I could inject my own opinions into the design because I understood the problem space. We were iterating on a design doc, not just generating code.
 

--- a/content/blog/from-nerd-sniped-to-shipped-using-ai-as-a-thinking-tool/contents.lr
+++ b/content/blog/from-nerd-sniped-to-shipped-using-ai-as-a-thinking-tool/contents.lr
@@ -116,7 +116,7 @@ And I could only build this effectively because I'd earned the right to automate
 
 ## How this approach scales: the power of AI-assisted pair coding
 
-I have a hypothesis that this approach works even better with two people and an AI assistant - but not more than two, because you can't have too many cooks. At Moderna's Data Science and AI teams, we instituted pair coding early on so we could help each other and share knowledge. Yes, we get less done in the same time, but in the long run, we move much faster. This shared knowledge means I can quickly jump onto someone else's codebase.
+I have a hypothesis that this approach works even better with two people and an AI assistant - but not more than two, because you can't have too many cooks. At Moderna's Data Science and AI teams, we instituted pair coding early on so we could help each other and share knowledge. Yes, we get less done in the same time, but in the long run, we move much faster. This shared knowledge means I can quickly jump into someone else's codebase.
 
 Pair coding as a practice needs maintenance though - I noticed recently I was getting isolated into solo coding. But during my Seattle trip, I experienced pair coding with AI assistance alongside my colleague Dan Luu from the ML Platform Team. We were learning prompting tips from each other, and it was incredible - we had a chance to share practices for how to use AI to amplify ourselves.
 


### PR DESCRIPTION
These really jumped out at me when I read this article. I hope you don't mind little PRs like this!

I suppose "jump _onto_ code" _could_ be what you meant, but I suspect "jump _into_ code" is more typical.