### PR TITLE
Undoing AI vibe-coded slop with AI

### DIFF
--- a/content/blog/creative-mentorship-strategies-for-career-growth-in-challenging-times/contents.lr
+++ b/content/blog/creative-mentorship-strategies-for-career-growth-in-challenging-times/contents.lr
@@ -28,13 +28,13 @@ Coaching others is a great way to build your reputation within the organization.
 
 ### Present at internal guilds and "birds of a feather" events
 
-At Moderna, we have guilds. At Novartis, the data science guild and the Computational Research Community (CRC) both served as outlets for talks and annual gatherings. The key is to be in a position where you can give a talk about something valuable to others, and they would willingly spend an hour listening to you. If that happens, you have created another mentorship opportunity for yourself.
+At Moderna's Digital organization, we have "Guilds", the Data Science Guild being one, with three meetings per month for the guild. When I was at Novartis' Research org, we had the Computational Research Community. Both served as outlets for talks and annual gatherings. The key is to be in a position where you can give a talk about something valuable to others, and they would willingly spend an hour listening to you. If that happens, you have created another mentorship opportunity for yourself.
 
 ### Organize communities of practice
 
-I have seen this happen when someone builds a tool that others use and then creates a community around that tool. It can be as simple as a Microsoft Teams group chat. You don't need anything more sophisticated than that. Just gather people who use the tool and facilitate discussions. Being a leader in that group chat is a real way to hone your leadership skills across the organization. My colleague [Albert Lam](https://www.linkedin.com/in/albert-lam/) built a significant portion of the internally-facing LLM tooling, and put together communities of practice around that precisely in the form of MS Teams group chats.
+I have seen this happen when someone builds a tool that others use and then creates a community around that tool. It can be as simple as a Microsoft Teams group chat. You don't need anything more sophisticated than that. Just gather people who use the tool and facilitate discussions. Being a leader in that group chat is a real way to hone your leadership skills across the organization. My colleague [Albert Lam](https://www.linkedin.com/in/albert-lam/) built a significant portion of the Python packages that are used by LLM builders, and put together communities of practice around that precisely in the form of MS Teams group chats.
 
-Another example is the community of practice around documentation - primarily expressed as the internal [docathons](/blog/2024/6/30/two-years-of-docathons-insights-and-lessons-learned/) that we run. My teammate Jackie Valeri, as well as two other colleagues [Simreen Kaur](https://www.linkedin.com/in/simreen-kaur/) and [Saakshi Shamanth Donthi](https://www.linkedin.com/in/saakshisdonthi/) help coordinate and organize the logistics while also being point contacts for other folks participating in the docathon.
+Another example is the community of practice around documentation - primarily expressed as the internal [docathons](/blog/2024/6/30/two-years-of-docathons-insights-and-lessons-learned/) that we run. My teammate [Jackie Valeri](https://jackievaleri.github.io/), as well as two other colleagues [Simreen Kaur](https://www.linkedin.com/in/simreen-kaur/) and [Saakshi Shamanth Donthi](https://www.linkedin.com/in/saakshisdonthi/) help coordinate and organize the logistics while also being point contacts for other folks participating in the docathon.
 
 ### Host informal coffee hours
 
@@ -42,7 +42,7 @@ My teammate, [Michelle Faits](https://mfaits.github.io/), took the initiative to
 
 ### Host or support external meetups
 
-We also host the PyData Boston/Cambridge monthly meetup at Moderna. Not every month is held at our location, but since I know the organizer [Ben Batorsky](https://benbatorsky.com/), back in 2025, I offered my time to book a room; we simply provide the space. More recently, my teammate [Jackie Valeri](https://jackievaleri.github.io/) has taken the lead in this. By taking charge and inviting others to network, we create opportunities for people to grow in their careers without any budget requirement.
+We also host the PyData Boston/Cambridge monthly meetup at Moderna. Not every month is held at our location, but since I know the organizer [Ben Batorsky](https://benbatorsky.com/), back in 2025, I offered my time to book a room; we simply provide the space. More recently, Jackie has taken the lead in this. By taking charge and inviting others to network, we create opportunities for people to grow in their careers without any budget requirement.
 
 ## Advice for managers
 
@@ -50,13 +50,15 @@ If you are a manager, recognize that there will be projects and efforts that nee
 
 Make sure you are aware of these kinds of initiatives among your reports, and ensure they don't conflict with core responsibilities. When someone can demonstrate that they manage these additional activities while maintaining their primary work, that forms a strong case for their expanded capabilities.
 
+We should expand our imagination beyond just climbing the career ladder, attaining higher status, or managing other people, which sometimes unfortunately spills over into controlling others at work. Growth comes in many forms, and we can find meaningful ways to develop without waiting for formal promotions or titles.
+
 ## The core principles
 
 Mentoring is about sharing your judgment, providing opportunities for others to share theirs, facilitating networking, and helping others grow. If we limit our understanding of growth and development to a narrow definition (only formal programs, only budgeted activities, only additional formal assignments), we constrain our imagination as managers.
 
 Don't be confined to a singular vision of what it means to be a good leader or manager. Embrace the diverse talents and varying stages of abilities within your team. Encourage your team members to step outside their comfort zones and provide them with opportunities to grow.
 
-You do not need an internal university to foster a learning culture. You environment is the university to learn and grow. We have more autonomy and agency than we might realize!
+While good, you do not necessarily need an internal university to foster a learning culture; your environment is where you learn and grow. We have more autonomy and agency than we might realize!
 ---
 pub_date: 2026-03-25
 ---

--- a/content/blog/undoing-ai-vibe-coded-slop-with-ai/contents.lr
+++ b/content/blog/undoing-ai-vibe-coded-slop-with-ai/contents.lr
@@ -1,0 +1,153 @@
+title: Undoing AI vibe-coded slop with AI
+---
+body:
+
+I want to tell you about canvas-chat, a project I built with heavy AI assistance. It's a visual, non-linear chat interface where conversations are nodes on an infinite canvas — think branching, merging, and exploring topics as a directed acyclic graph.
+
+The first commit landed on December 28, 2025. By December 30, it had sessions, matrix evaluation tables, web search, node tagging, and BM25 keyword search. The AI moved _fast_. Bugs got fixed in the next commit. Features piled in like tetris blocks stacking up.
+
+And yes, it was a mess.
+
+Here's the thing though: the mess was _recoverable_. Not because the AI got better (it didn't; not really), but because I had battle-tested convictions on how the thing _ought_ to be architected. And those convictions came from years of shipping software, watching architectures crumble, and learning what holds up.
+
+This is the story of how we went from a jumbled 8,500-line `app.js` to a clean plugin architecture — and why you need battle-tested convictions to make that happen.
+
+## The Initial State
+
+The first commit wasn't actually _bad_. The project had clean separation from day one:
+
+- `canvas.js` — SVG pan/zoom/rendering
+- `graph.js` — DAG data structure
+- `chat.js` — LLM API + SSE streaming
+- `storage.js` — IndexedDB persistence
+- `app.py` — FastAPI backend
+
+But `app.js` was already ~8,500 lines of everything else. Every slash command handler, every modal, every feature logic — all tangled together. Want to add a new feature? You'd grep around in that monolith, hope you found the right spot, and pray you didn't break anything.
+
+The AI could add features to this mess. It could add a `/matrix` command in a few prompts. It could add `/search` with Exa integration. But it couldn't see the _structure_ — the latent architecture that would make the whole thing maintainable.
+
+## The First Wave
+
+The refactoring started with the purest code — functions with no dependencies:
+
+| Date   | What Got Extracted   | Why                                                                                    |
+| ------ | -------------------- | -------------------------------------------------------------------------------------- |
+| Jan 4  | `layout.js`          | Overlap detection is pure math                                                         |
+| Jan 5  | `highlight-utils.js` | Text selection is isolated                                                             |
+| Jan 7  | Feature modules      | `flashcards.js`, `committee.js`, `matrix.js`, `factcheck.js`, `research.js`, `code.js` |
+| Jan 10 | Core infrastructure  | `undo-manager.js`, `modal-manager.js`, `slash-command-menu.js`                         |
+
+This reduced `app.js` from ~8,500 to ~5,500 lines. But these were still just _file splits_. The code worked better, but there was no _system_ binding it together.
+
+The AI did this part reasonably well — when I asked "extract this function to a separate module," it could do it. But it never suggested "we should extract this" on its own. It needed direction.
+
+## The Pivotal Moment
+
+This was the architectural leap. I asked the AI to create a plugin system, and it delivered — but only because I knew what a plugin system _should_ look like.
+
+We ended up with a **three-level plugin architecture**:
+
+**Level 1: Custom Node Types** — Node protocols define rendering via a `BaseNode` class. Each node type can override `renderContent()`, `getActions()`, `getSummaryText()`, and more. Registered in `node-registry.js`.
+
+**Level 2: Feature Plugins** — Extend a `FeaturePlugin` base class. Get `AppContext` via dependency injection (graph, canvas, chat, storage, modalManager, streamingManager). Define slash commands via `getSlashCommands()`. Lifecycle hooks: `onLoad()`, `onUnload()`.
+
+**Level 3: Extension Hooks** — Subscribe to events. `CancellableEvent` can block actions. Event names like `command:before`, `node:created`, `node:deleted`.
+
+The key files created:
+
+- `feature-plugin.js` — FeaturePlugin + AppContext
+- `feature-registry.js` — Slash command routing with priority (BUILTIN > OFFICIAL > COMMUNITY)
+- `plugin-events.js` — CanvasEvent, CancellableEvent
+- `node-registry.js` — Node type registration
+
+This is where the architecture became a real system. And it only happened because I knew what I wanted.
+
+## Backend Pluginification (Late January 2026)
+
+The same pattern reached the Python side:
+
+- `pptx_endpoints.py` — PowerPoint handling
+- `ddg_endpoints.py` — DuckDuckGo search
+- `code_handler.py` — Python code execution
+- `matrix_handler.py` — Matrix cell filling
+
+Each follows a `register_endpoints(app)` pattern, loaded dynamically via `importlib`.
+
+## The Testing Safety Net
+
+By late January, the plugin architecture was in place. Features were decoupled. The code was cleaner. And then GLM-4.5 started dropping curly braces.
+
+No, really. The AI would "fix" one thing and introduce a missing bracket somewhere else. Merge conflicts became minefields; features that worked yesterday stopped working today; not because of malice, but because the AI didn't understand the dependencies between modules. It was making elementary mistakes that a junior developer wouldn't make.
+
+On January 24, I added Cypress E2E tests. Out of spite, honestly. The first commit gave us `canvas_interactions.cy.js`, `node_selection.cy.js`, and `note_node.cy.js` - three tests that told us whether the canvas still worked.
+
+These tests caught the regressions the AI kept introducing. More importantly, they let me verify changes faster. Instead of manually testing every feature after each AI session, I could run the test suite and know whether things still worked.
+
+The plugin architecture made the code testable. The tests caught what the AI broke.
+
+## The Numbers
+
+| Phase                  | app.js size  | Modules     |
+| ---------------------- | ------------ | ----------- |
+| Initial (Dec 2025)     | ~8,500 lines | 5 files     |
+| After feature splits   | ~5,500 lines | 11 files    |
+| After infrastructure   | ~5,400 lines | 15 files    |
+| After plugin migration | ~5,400 lines | 25+ files   |
+| Today                  | ~4,700 lines | 35+ modules |
+
+## The Bigger Lesson
+
+Here's what I learned from this process:
+
+**The AI can execute architecture, but it can't design it.** It can split files when asked. It can implement a plugin system from a spec. But it won't look at a 8,500-line `app.js` and say "this should be a plugin system."
+
+That vision; that _opinion_; comes from somewhere else. It comes from:
+
+1. **Seeing architectures fail** - Knowing the pain of tangled code, merged conflicts, feature creep
+2. **Seeing architectures succeed** - Knowing what maintainable code feels like after years of shipping
+3. **Reading, studying, internalizing** - Design patterns, architectural styles, tradeoffs
+4. **Making mistakes** - Building the wrong abstraction once so you recognize it next time
+
+I didn't arrive at "we need a three-level plugin architecture" out of nowhere. It came from discussing tradeoffs with the AI; asking "what if we did it this way?" and "what are the tradeoffs of that approach?"; and applying my best judgment to the options. The AI could explain the pros and cons of different approaches, but I had to pick which tradeoffs I was willing to accept.
+
+The AI didn't teach me this. _Experience_ taught me this.
+
+## What This Means for the Future
+
+Here's where it gets interesting. Because we built this modular foundation, I can now swap out the rendering layer. The canvas is currently raw SVG — and I want to move to Svelte Flow. The plugin system I built makes this possible:
+
+- Features don't depend on `app.js` internals; they use `AppContext`
+- Canvas is isolated in `canvas.js`; swapping to Svelte Flow means replacing that layer
+- Node protocols define behavior; Svelte Flow nodes can use the same protocol pattern
+- Event system is framework-agnostic
+- Dependency injection provides graph, canvas, chat, storage; these can be re-provided to Svelte Flow components
+
+The abstraction layer we built; FeaturePlugin + AppContext + EventSystem; separates _what_ features do from _how_ they're rendered. That's what makes Svelte Flow viable as a drop-in replacement.
+
+## Closing Thoughts
+
+You can undo AI vibe-coded slop. It's possible. But it requires _you_ to have battle-tested convictions on how the thing ought to be.
+
+The AI is an incredible executor. It can refactor, extract, implement. But the vision? That stays human. And that vision comes from battle-tested experience; from having seen enough codebases to know what works and what collapses under its own weight.
+
+So if you're working with AI coding assistants: don't expect them to architect for you. Tell them what to build. Give them the structure. Then let them do the implementation.
+
+That's how you get from a jumbled mess to something you can actually maintain.
+---
+summary: I vibe-coded canvas-chat into existence in 48 hours, then spent weeks untangling the mess into a clean plugin architecture. The AI could execute my architectural vision, but it couldn't design it. This is the story of how I recovered from AI-generated slop — and why the architecture stays human.
+---
+author: Eric J. Ma
+---
+pub_date: 2026-03-29
+---
+tags:
+
+ai
+llm
+coding
+architecture
+plugins
+opencode
+tools
+---
+twitter_handle: ericmjl


### PR DESCRIPTION
## Summary

- Blog post documenting how I recovered canvas-chat from a jumbled 8,500-line app.js to a clean plugin architecture
- Key theme: AI can execute architectural vision but cannot design it — the architecture stays human
- Covers the three-level plugin system, Cypress testing safety net, and lessons learned

## Changes

- New blog post: `content/blog/undoing-ai-vibe-coded-slop-with-ai/contents.lr`