### PR TITLE
User manual: direct resolution before mediation

### DIFF
--- a/content/user-manual/contents.lr
+++ b/content/user-manual/contents.lr
@@ -43,6 +43,9 @@ For my complete collection of shell aliases, see [my data science bootstrap note
 **Cultivate your network.**
 Find a few people inside or outside your team whose feedback you trust and whose knowledge you can draw from. Learning doesn’t have to be top-down.
 
+**If I am pulled in on people problems, I need the real conversation, not telephone.**
+Interpersonal or coordination issues should be handled directly between the people involved first; that is the mature default on a professional team. If it still makes sense to bring me in as a mediator, loop everyone who matters into the same discussion with a full, first-hand picture. I do not want to arbitrate from partial accounts or second-hand retellings.
+
 **Interview externally once a year.**
 It’s a healthy habit. For everyone, it helps keep your interviewing muscle strong and gives you a clearer view of the industry. If you’re working directly with me and I’m your line manager, feel free to share — it gives me a sense of your ambitions. I treat it as data, not disloyalty.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the user manual with an explicit expectation for interpersonal and coordination issues: colleagues should address each other directly first, and if mediation is still needed, everyone relevant should be in one conversation with first-hand context rather than partial or relayed accounts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16261267-ab0b-411e-8f6c-335570d1d195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16261267-ab0b-411e-8f6c-335570d1d195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

