### PR TITLE
feat(apps/video-editor): fix kebab-case composition lookup + transcript readability

### DIFF
--- a/apps/bots/video-editor/server/index.ts
+++ b/apps/bots/video-editor/server/index.ts
@@ -46,7 +46,8 @@ function discoverCompositions(): Composition[] {
 // Extracts STEP_BOUNDARIES from the .tsx source using regex
 function parseStepBoundaries(compositionId: string): any[] {
   // Try to find the video source file
-  const PascalName = compositionId.charAt(0).toUpperCase() + compositionId.slice(1);
+  // Convert kebab-case to PascalCase: "agents-amplify" -> "AgentsAmplify"
+  const PascalName = compositionId.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join("");
   const sourcePath = join(REMOTION_DIR, "src", `${PascalName}Video.tsx`);
   if (!existsSync(sourcePath)) return [];
 
@@ -105,7 +106,7 @@ app.post("/api/fix", (req, res) => {
   if (!compositionId || !feedback) return res.status(400).json({ error: "Missing compositionId or feedback" });
 
   const jobId = `fix-${Date.now()}`;
-  const PascalName = compositionId.charAt(0).toUpperCase() + compositionId.slice(1);
+  const PascalName = compositionId.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join("");
   const job: FixJob = { id: jobId, status: "running", log: "", compositionId };
   jobs.set(jobId, job);
 

--- a/apps/bots/video-editor/src/App.tsx
+++ b/apps/bots/video-editor/src/App.tsx
@@ -381,11 +381,11 @@ function Transcript({ words, currentIdx, onSeek }: {
   if (current.text) sentences.push(current);
 
   return (
-    <div ref={containerRef} style={{ lineHeight: 1.8, fontSize: 12 }}>
+    <div ref={containerRef} style={{ lineHeight: 1.6, fontSize: 13 }}>
       {sentences.map((s, si) => {
         const isActive = s.wordIndices.includes(currentIdx);
         return (
-          <span
+          <div
             key={si}
             onClick={() => onSeek(s.start)}
             style={{
@@ -393,12 +393,13 @@ function Transcript({ words, currentIdx, onSeek }: {
               color: isActive ? COLORS.primary : COLORS.textDim,
               background: isActive ? "rgba(98, 196, 255, 0.1)" : "transparent",
               borderRadius: 3,
-              padding: "1px 2px",
+              padding: "3px 6px",
+              marginBottom: 4,
             }}
             ref={isActive ? currentRef : undefined}
           >
-            {s.text.trim()}{" "}
-          </span>
+            {s.text.trim()}
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
Two small video-editor fixes split off from the Ollama/vLLM/SGLang blog PR so that branch stays focused on the blog post.

- **fix:** kebab-case composition IDs (e.g. `agents-amplify`) now convert to PascalCase (`AgentsAmplify`) so the matching `*Video.tsx` source resolves. Previously only the first character was capitalized, so step-boundary parsing and `/api/fix` silently no-op'd.
- **feat:** transcript readability tweaks (font size 13, line height 1.6, block layout with padding).