### PR TITLE
docs(agents): prefer direct, first-person voice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ recent published blog posts for sentence rhythm and flow when editing.
 When drafting or editing blog posts and content in my voice, apply these
 habits so the result matches how I would write it:
 
+- Prefer **direct, first-person, agent-explicit** phrasing: name the real
+  actor as the subject ("we assumed", "we chose"), not an inanimate thing
+  ("the picture assumed", "the model suggests"). Avoid agent-effacing and
+  anthropomorphized constructions; they read as stiff and unaccountable.
 - Make logical links explicit (e.g. "this meant …" when clarifying what
   something implies). State stakes or consequences before giving advice.
 - Break up long paragraphs; give key takeaways their own sentence and use


### PR DESCRIPTION
## Summary
- Adds a voice rule to `AGENTS.md`: prefer **direct, first-person, agent-explicit** phrasing (name the real actor as the subject, e.g. "we assumed", not "the picture assumed"); avoid agent-effacing and anthropomorphized constructions.
- Captures Eric's stated preference (direct + first-person writing style) so future blog/content edits honor it.