### PR TITLE
style: make iframes borderless site-wide and drop per-embed border customizations

### DIFF
--- a/assets/static/css/custom.css
+++ b/assets/static/css/custom.css
@@ -16,6 +16,11 @@ body {
   font-family: 'Berkeley Mono', monospace;
 }
 
+/* Strip borders from every iframe site-wide so embeds sit flush with the page. */
+iframe {
+  border: none;
+}
+
 .blog-summary {
   padding-top: 2em;
 }

--- a/content/blog/ai-turbocharges-learning/contents.lr
+++ b/content/blog/ai-turbocharges-learning/contents.lr
@@ -14,7 +14,7 @@ None of the techniques are new. Retrieval practice, spaced repetition, elaborati
 
 Before you read on, I'd like to invite you to try these three, even if you're just guessing. Recalling first is what makes the rest of the post stick. Then keep reading. By the end, you'll know which of your answers the evidence supports.
 
-<iframe src="before-you-read.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="before-you-read.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 ## The central distinction: amplifier or substitute
 
@@ -30,7 +30,7 @@ Flip the prompt and everything changes. Instead of "explain X to me," she types:
 
 To see if you got the idea, try the little quiz below. Decide for each whether the learner is amplifying their thinking or substituting for it.
 
-<iframe src="prompt-inspector.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="prompt-inspector.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 If you noticed the pattern, there's really only one question that matters: who's generating the thinking, and thus the words? Every study and every story below comes back to that.
 
@@ -46,7 +46,7 @@ A [second meta-analysis](https://www.frontiersin.org/journals/psychology/article
 
 To help you see the pattern for yourself, I collated the studies into the map below. Click any one for the design, the sample, and the effect size. Here's what to observe: scaffold the AI and the effects are large; leave it unguided and they flip.
 
-<iframe src="evidence-map.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="evidence-map.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Two studies in that map are worth slowing down for. One shows what a good scaffold buys you; the other shows what happens when you don't use one. At the strong end, a [World Bank trial in Nigeria](https://documents1.worldbank.org/curated/en/099548105192529324/pdf/IDU-c09f40d8-9ff8-42dc-b315-591157499be7.pdf) gave roughly 800 students free Microsoft Copilot alongside a six-week afterschool program, with tutors grounding the AI in the curriculum. The result was a 0.31 standard deviation gain, which the authors translate into roughly 1.5 to 2 years of business-as-usual schooling in Nigeria compressed into six weeks.
 
@@ -74,7 +74,7 @@ The third principle is the testing effect, and it's what happens when retrieval 
 
 Want to see the forgetting curve in action? Pick a strategy below and watch what happens to retention over two weeks.
 
-<iframe src="forgetting-curve.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="forgetting-curve.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 The [UniDistance study](https://doi.org/10.48550/arxiv.2309.13060) is the cleanest field test of all three principles at once. Researchers gave 51 students a semester-long AI tutor (the MAGMA Learning app) that used a neural network to model each student's grasp of every concept, then served questions at each student's moment of near-forgetting, and visualized mastery as a 3D "learnet" whose brightness tracked grasp. Spacing, retrieval, and personalization, all automated.
 
@@ -112,7 +112,7 @@ AI amplifies what you bring. If you already know how to study, it supercharges y
 
 Bloom's lower levels (remember, understand, apply) are commoditized. The model does them faster than you. Value has moved up to analyze, evaluate, create. **The differentiator is what you do on top of having the information.** The meta-skill that compounds is driving higher-order questioning and judgment.
 
-<iframe src="blooms-taxonomy.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="blooms-taxonomy.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 So what's the counter to "brain rot"? Self-directed learning. The people who thrive with AI are the ones who drive the questioning the model won't generate on its own, check the output against their own understanding, and treat the model as a coach rather than an oracle. It's a habit of mind, not a feature you can toggle.
 
@@ -120,7 +120,7 @@ So what's the counter to "brain rot"? Self-directed learning. The people who thr
 
 Those three questions I invited you to try at the top? You now have the evidence to answer every one. Here's a five-question quiz to check what stuck.
 
-<iframe src="check-understanding.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="check-understanding.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Here's my parting advice: take the prompt swap. Next time you open a model to learn, tell it what you think and ask where you're wrong. The model won't be any different. You will.
 

--- a/content/blog/build-your-own-tools/contents.lr
+++ b/content/blog/build-your-own-tools/contents.lr
@@ -111,19 +111,19 @@ And here's a side effect: we designed a portable way of working that works best 
 
 As it turns out, this evening's other presenter [Tommy Tang](https://www.linkedin.com/in/%F0%9F%8E%AF-ming-tommy-tang-40650014/) is also a big fan of the shell:
 
-<iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7341052068264128513?collapsed=0" height="265" width="504" frameborder="0" allowfullscreen="" title="Embedded post"></iframe>
+<iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7341052068264128513?collapsed=0" height="265" width="504" allowfullscreen="" title="Embedded post"></iframe>
 
 So now I'm a big fan of giving people access to a raw Linux box, outside of a sandboxed container. Being able to build and run a container is a fundamental skill nowadays—so much so that as a community of data scientists, we've effectively said "no" to vendor tooling that forces us to do our day-to-day work within a Docker container.
 
 And here's the most awesome part: we did this in an "internally open source" fashion. *Anyone* with a complaint about the tooling can propose a fix to our tools. Even better, we'll walk you through making the fix "the right way," so you gain the superpower of software development along the way!
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/3ZTGwcHQfLY?si=_FLzvFyCp88ZlzGm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/3ZTGwcHQfLY?si=_FLzvFyCp88ZlzGm" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 At least on this dimension, we are never beholden to someone else's (or a vendor's) roadmap! We are now _resilient_—just like Dustin from Smarter Every Day described when he made this video about trying to make things "in America."
 
 I'll end this section with a huge lesson I've learned during my time working here:
 
-<iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7337223460651220992" height="349" width="504" frameborder="0" allowfullscreen="" title="Embedded post"></iframe>
+<iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7337223460651220992" height="349" width="504" allowfullscreen="" title="Embedded post"></iframe>
 
 ## Building teaches you the domain
 

--- a/content/blog/dissecting-the-esm3-model-architecture/contents.lr
+++ b/content/blog/dissecting-the-esm3-model-architecture/contents.lr
@@ -201,7 +201,7 @@ I did this deep dive to give us a geometric intuition of what's happening in vec
 
 Let's revisit the ESM model architecture once again. It looks like this:
 
-<iframe src="https://link.excalidraw.com/readonly/iQTxShs9tZzKqNczk6ps" width="100%" height="100%" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/iQTxShs9tZzKqNczk6ps" width="100%" height="100%"></iframe>
 
 Each modality is in red, green, or blue (apologies for the colour-blind; I am using Excalidraw's default colours). Modalities are masked to different degrees, represented by cross-hatched positions (you may need to zoom into the figure to see them). Summation happens after we calculate the per-modality embeddings for each sample, giving us an array of shape `(sequence_length, model_dimension)` per sample. It is passed through the Transformer block before decoding, where the decoder is nothing more than a feed-forward neural network that is applied to each position independently.
 

--- a/content/blog/embracing-leadership-my-journey-at-moderna/contents.lr
+++ b/content/blog/embracing-leadership-my-journey-at-moderna/contents.lr
@@ -94,7 +94,7 @@ Also, credit is not a zero-sum game; credit multiplies the more we give it away.
 As such, it's important that we continually recognize
 the contributions of our teammates and collaborators.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=dRLxWxEHkIz73LvD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="margin-left: auto; margin-right: auto; display: block"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=dRLxWxEHkIz73LvD" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="margin-left: auto; margin-right: auto; display: block"></iframe>
 
 <br>
 

--- a/content/blog/going-bayesian-automates-data-analysis/contents.lr
+++ b/content/blog/going-bayesian-automates-data-analysis/contents.lr
@@ -35,7 +35,7 @@ For every curve, there's usually a point or two that looks off. The standard wor
 
 For one curve, it'll be seconds, but multiply this over dozens of plates and you have an unbounded amount of time spent clicking on a UI (if one's lucky) or switching between two applications, Excel and GraphPad Prism (if one is unlucky).
 
-<iframe src="outlier-dance.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="outlier-dance.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Are you really going to hire more research assistants to click through curves? That approach collapses under its own weight.
 
@@ -53,7 +53,7 @@ The first is reproducibility. What's your rule for calling something an outlier?
 
 Here is curve 11 from the demo above, reviewed by two different analysts. Dilution 4 reads 100%, which looks like it belongs to the upper plateau. But the transition zone expects something closer to 73% at that dilution. Analyst A keeps it; Analyst B removes it. Toggle between them and watch the ID50 shift.
 
-<iframe src="two-analysts.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="two-analysts.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Same data, same software, different ID50. The point at dilution 4 sits right at the inflection of the curve, so keeping or removing it swings the estimate of where the curve crosses 50%. Which analyst is right? Both think they are, and without a principled criterion, neither can prove the other wrong.
 
@@ -75,7 +75,7 @@ And critically, the point is never deleted. It still contributes to the fit, jus
 
 Enough theory. Let me show you what this actually looks like on a dose-response curve with a real outlier.
 
-<iframe src="bayesian_curves_demo.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="bayesian_curves_demo.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 The blue curve is the Normal likelihood fit; the orange dashed curve is the Student-t. Dotted vertical lines mark each model's ID50 estimate. Shaded bands are 94% credible intervals from 4,000 posterior draws (PyMC/NUTS, 4 chains). The buttons go from nu=1 (the Student-t at its heaviest-tailed, most forgiving of outliers) to nu=30 (nearly indistinguishable from the Normal, least forgiving).
 
@@ -91,7 +91,7 @@ This is where hierarchical modeling earns its keep. Instead of fitting each curv
 
 The philosophy mirrors the heavy tails, just one level up. Heavy tails down-weight weird points. Hierarchy regularizes weird curves. It's the same idea, merely applied at different scales.
 
-<iframe src="hierarchy-demo.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="hierarchy-demo.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Six curves from the same experiment. Five came out clean; curve 3 had a bad day with noisy wells. Toggle between independent fits (curve 3 flails) and hierarchical fits (curve 3 borrows strength from the population and snaps into shape). The faint dashed line on curve 3 shows where the population says it should sit.
 

--- a/content/blog/how-to-automate-the-creation-of-google-docs-with-python/contents.lr
+++ b/content/blog/how-to-automate-the-creation-of-google-docs-with-python/contents.lr
@@ -76,7 +76,7 @@ will get you to the place where you will have
 
 _(Best viewed on a desktop browser!)_
 
-<iframe src="slides.html" width="100%" height="500vh" frameborder="0" scrolling="no"></iframe>
+<iframe src="slides.html" width="100%" height="500vh" scrolling="no"></iframe>
 
 <br>
 

--- a/content/blog/how-to-thrive-and-not-just-survive-during-organizational-change/contents.lr
+++ b/content/blog/how-to-thrive-and-not-just-survive-during-organizational-change/contents.lr
@@ -33,7 +33,7 @@ Here’s why: people notice. When you show that you’re steady and reliable, ev
 
 I think we have something to learn from President Obama:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=_tkyjLX25IWCfF0L" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=_tkyjLX25IWCfF0L" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Build your own optionality
 

--- a/content/blog/let-me-ship-you-the-python-you-need/contents.lr
+++ b/content/blog/let-me-ship-you-the-python-you-need/contents.lr
@@ -8,7 +8,7 @@ Recently, I watched Peter Wang's PyBay talk, [The Five Demons of Python Packagin
 
 > ...I don't care you'll get a Python we'll get you the Python you need what's the thing you want to do
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/qA7NVwmx3gw?si=LJHDuLLQo6kpdU9x&amp;start=2183" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qA7NVwmx3gw?si=LJHDuLLQo6kpdU9x&amp;start=2183" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 <br>
 <br>

--- a/content/blog/multi-modality-deep-learning/contents.lr
+++ b/content/blog/multi-modality-deep-learning/contents.lr
@@ -96,7 +96,7 @@ def info_nce_loss(image_embeddings, text_embeddings, temperature=0.07):
 
 And in pictorial form, using a batch size of 3 for illustration purposes:
 
-<iframe src="https://link.excalidraw.com/readonly/Ts99jTtb4S4rcCu3huv7" width="100%" height="400px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/Ts99jTtb4S4rcCu3huv7" width="100%" height="400px"></iframe>
 
 This objective is presumably important because aligning embeddings ensures semantic similarity in embedding space for pairs of input data.
 
@@ -114,7 +114,7 @@ This objective is important because it produces embeddings of the protein sequen
 
 Having studied the learning objectives in detail, the final ingredient that interests me is the actual model architecture. Unfortunately, no figure is provided here, so I had to dig through the Appendix to figure it out. Based on the textual description in Appendix A of the paper, here is my best guess representation of what the model looks like.
 
-<iframe src="https://link.excalidraw.com/readonly/hQVib4XpGpAO1TLwag48" width="100%" height="400px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/hQVib4XpGpAO1TLwag48" width="100%" height="400px"></iframe>
 
 In the diagram, arrays have no box around them, models have a blue box around them, and loss functions have a red box around them. For the arrays, I have annotated in small text what is the array shape. For the models, small text annotations outline the essential architectural gist of the model. Small text annotations name the specific loss function used for the loss functions.
 
@@ -132,7 +132,7 @@ First, we must identify what we mean by "use the model." Let's consider a few us
 
 In this use case, the available modality is the protein sequence, and the absent modality is the textual description. One could add to the model a training objective that reconstructs a protein's natural language description of function from the protein sequence, in which the PLM embedding is used to decode the natural language description autoregressively. This is the Function Prediction arm of the model outlined in the image below.
 
-<iframe src="https://link.excalidraw.com/readonly/FIKiAzcxX7vflJi6fU4i" width="100%" height="600px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/FIKiAzcxX7vflJi6fU4i" width="100%" height="600px"></iframe>
 
 #### Use case 2: protein sequence generation from functional description
 
@@ -148,7 +148,7 @@ What if we added only one objective: a neural network that converts between the 
 
 When thinking about the ProST model and how to modify it, I also had a chance to think more critically about the difference between masked language modelling and auto-regressive text generation. Thanks to my teammates at Moderna, I’ve realized that masked language modelling is a more natural fit for small-scale edits (in-filling) conditioned on the rest of the sequence context. At the same time, auto-regressive text generation is a more natural fit for de novo generation.
 
-<iframe src="https://link.excalidraw.com/readonly/R2m0k7rF5LjtWjJqqoOX" width="100%" height="200px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/R2m0k7rF5LjtWjJqqoOX" width="100%" height="200px"></iframe>
 
 Nonetheless, it should be clear that both model classes are usable for both applications; it’s just that they have more naturally fitting applications, respectively.
 ---

--- a/content/blog/quantum-ml-for-the-probabilistic-bayesian/contents.lr
+++ b/content/blog/quantum-ml-for-the-probabilistic-bayesian/contents.lr
@@ -12,13 +12,13 @@ Here is the angle I am going to take. I have been doing Bayesian modeling for ye
 
 If you're ready for the ride, here we go!
 
-<iframe src="before-you-read.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="before-you-read.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 ## The fundamentals
 
 Start with the most fundamental object in quantum computing: the state of a single qubit. A one-qubit state is an arrow of length 1 in a two-dimensional space whose axes are the two basic states |0> and |1>. The arrow's coordinates along those axes are its amplitudes. Because the arrow has length 1, its tip sits on a unit circle, a slice of the Bloch sphere (the standard name for the full qubit state space).
 
-<iframe src="bloch-circle.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="bloch-circle.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Drag the arrow above. Its projections onto the |0> and |1> axes are the amplitudes, and the squares of those projections are the probabilities of measuring |0> or |1>. That squaring is the bridge into your world as a probabilistic Bayesian, and it is the lens we will use for the rest of the post. The new ingredient, with no analogue in classical probability, is that amplitudes carry a sign: the arrow can point anywhere on the circle, including where a coordinate is negative. That signedness stays quiet for a single measurement, but it is the seed of everything quantum that follows.
 
@@ -35,7 +35,7 @@ That picture was for one qubit, which lives in two dimensions. Add a second qubi
 
 Play with the doubling below: one qubit gives two amplitudes, two qubits give four, three give eight.
 
-<iframe src="many-qubits.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="many-qubits.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 This is the first place quantum computing leaves classical intuition behind, and it leaves fast. A 50-qubit register has 2^50 amplitudes, more than a quadrillion; you cannot write them all down, let alone store the state on a classical machine. Measuring collapses that whole arrow to a single bitstring, drawn with probability equal to its amplitude squared, the many-qubit version of what the Bloch circle showed.
 
@@ -47,7 +47,7 @@ Before we move on, we should make this picture second nature. Drag the circles u
 
 Step back from amplitudes for a moment. If you only care about what a measurement will tell you, a qubit behaves like a biased coin, and a register of qubits like a pile of coins. That is the probabilistic-Bayesian lens I promised in the intro, and I will lean on it for the rest of the post; the widget below lets you flip 1, 2, or 3 and watch the outcomes follow the distribution. Just remember the coin view is a simplification, the shadow the amplitudes cast on a measurement, and it hides the signs that the interference section later puts to work.
 
-<iframe src="qubit-measurement.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="qubit-measurement.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 ### Entanglement
 
@@ -55,7 +55,7 @@ Entanglement, in this framing, is when the state of one qubit cannot be describe
 
 Here is that idea made geometric. Two dials below set the qubits as if they were independent; the entanglement dial mixes in correlation. Watch the joint amplitudes stop factorizing, and the concurrence climb from 0 (independent) toward 1 (maximally entangled).
 
-<iframe src="two-qubit-entanglement.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="two-qubit-entanglement.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 ### Interference
 
@@ -63,7 +63,7 @@ An amplitude's sign is easy to ignore, because a single measurement only sees th
 
 One tool that does the mixing is the Hadamard gate. It takes any input state and produces a specific output by blending the two input amplitudes together, with a minus sign baked into one of the blends. The widget below lets you drag the input arrow and watch the output respond. The butterfly diagram in the middle traces each input amplitude as it splits into contributions at each output, so you can see exactly where reinforcement and cancellation happen.
 
-<iframe src="hadamard-gate.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="hadamard-gate.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Drag the input to the diagonal (45 degrees, the |+> state) and look at the butterfly. Two contributions arrive at each output. At output |0>, both are positive, so they reinforce, and the output arrow swings hard toward |0>. At output |1>, one is positive and one is negative, so they cancel, and |1> vanishes. That is interference made visible: the minus sign killed one output while boosting the other. Now drag to other angles and watch how the balance between reinforcement and cancellation shifts. When only one input amplitude is nonzero (try |0> or |1>), there is only one path through the gate, so nothing cancels.
 
@@ -81,7 +81,7 @@ What if you didn't have to enumerate a combinatorial space at all, but instead l
 
 That's the quantum computer's party trick. It isn't a magical exponential speedup for everything. But it can be viewed as an MCMC sampler, purpose-built for exactly the kind of problem we already wrestle with: inference over spaces too big to enumerate classically.
 
-<iframe src="check-understanding.html" width="100%" scrolling="no" style="border: none;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="check-understanding.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 ## The takeaway
 

--- a/content/blog/reproducible-pi-manifesto/contents.lr
+++ b/content/blog/reproducible-pi-manifesto/contents.lr
@@ -6,7 +6,7 @@ body:
 
 I found this set of slides by [Lorena Barba](http://lorenabarba.com): the Reproducible PI Manifesto. I love it, and I hope other PIs take it up!
 
-<iframe src="https://widgets.figshare.com/articles/104539/embed?show_title=1" width="568" height="716" frameborder="0"></iframe>
+<iframe src="https://widgets.figshare.com/articles/104539/embed?show_title=1" width="568" height="716"></iframe>
 ---
 pub_date: 2016-10-09
 ---

--- a/content/blog/rethinking-llm-interfaces-from-chatbots-to-contextual-applications/contents.lr
+++ b/content/blog/rethinking-llm-interfaces-from-chatbots-to-contextual-applications/contents.lr
@@ -34,7 +34,7 @@ Pike showed examples of right-click contextual actions, natural language search 
 
 I thought the talk was quite good, and I'm embedding it below to share.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/mRqBjKFyfLc?si=9sRDPg-hH5iBLiFf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/mRqBjKFyfLc?si=9sRDPg-hH5iBLiFf" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Jobs to be done theory meets LLM apps
 

--- a/content/blog/the-neural-von-mises-mixture-model/contents.lr
+++ b/content/blog/the-neural-von-mises-mixture-model/contents.lr
@@ -10,7 +10,7 @@ I came across this paper, "[The Continuous Language of Protein Structure](https:
 
 Indeed, most of the autoregressive neural network models we have seen generate _discrete_ outputs, such as tokens from a tokenization scheme that maps letters, words, or word fragments to those tokens. However, if one stares hard enough at the structure of such models, they generate a multinomial distribution over tokens, from which we then sample the discrete tokens (categories).
 
-<iframe src="https://link.excalidraw.com/readonly/DIEeWc2GhHFYtE7iGNGE" width="100%" height="300px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/DIEeWc2GhHFYtE7iGNGE" width="100%" height="300px"></iframe>
 
 So, strictly speaking, the outputs of an autoregressive language model are nothing more than continuous values that we "interpret" as being the probability distribution parameter values associated with this long multinomial probability vector, thus drawing a _discrete_ categorical value from that distribution. If so, what's stopping us from producing the probability distribution parameters associated with other things that may also be continuous-valued? Why not produce the parameters of a probability distribution from which we sample _continuous_ values?
 
@@ -20,7 +20,7 @@ What, then, does all of this have to do with the von Mises distribution and the 
 
 This is related to the *scientific* premise of the paper, which is to generate protein backbones. Every protein structure comprises amino acids arranged in some 3-dimensional conformation, and between the backbone chain of $N$, $C_\alpha$, and $C$ atoms, there exists phi ($\phi$), psi ($\psi$), and omega ($\omega$) angles associated, which are also known as the torsion or dihedral angles. Below, I simplify an illustration from [Justas Dauparas' excellent blog post](https://dauparas.github.io/post/af2/):
 
-<iframe src="https://link.excalidraw.com/readonly/oeN2gctwjLfuzzWEsqTr" width="100%" height="600px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/oeN2gctwjLfuzzWEsqTr" width="100%" height="600px"></iframe>
 
 All credit to Justas Dauparas for the original illustration, from which I created a simplification. In the illustration above:
 
@@ -110,7 +110,7 @@ According to the paper, each residue's angles are calculated from a factorized j
 
 I've modified the original figure provided by the authors to annotate clearly (for myself) where neural networks exist and what their outputs are.
 
-<iframe src="https://link.excalidraw.com/readonly/uZeW71dYxAJtVu4TfGoE" width="100%" height="600px" style="border: none;"></iframe>
+<iframe src="https://link.excalidraw.com/readonly/uZeW71dYxAJtVu4TfGoE" width="100%" height="600px"></iframe>
 
 Here is how information flows through the model. If we focus in on $S_{t+1}$ (the right blue box), we can first see the autoregressive nature of the beast.
 

--- a/content/blog/the-selfish-reason-to-do-your-best-work/contents.lr
+++ b/content/blog/the-selfish-reason-to-do-your-best-work/contents.lr
@@ -22,7 +22,7 @@ But even if you can’t find much to be inspired by, do your best work anyway. W
 
 President Obama once gave this advice to young interns: "Don't ask for the plum assignments. Just knock out everything you're doing." I guarantee you someone will notice. Even if no one at your current company notices, if you build a track record of quality, people *outside* will notice.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=_tkyjLX25IWCfF0L" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/YNY4UFaHbP4?si=_tkyjLX25IWCfF0L" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Your reputation precedes you. It is the one thing you accumulate over time that serves as a form of wealth that can never be taken away from you. Only you can lose it. To borrow a phrase from Jocko Willink, this is "Extreme Ownership"—taking total responsibility for your world. Yes, circumstances happen, but if you guard your reputation well, it is yours to keep.
 

--- a/content/blog/understanding-zeitgeist-ai-code-review/contents.lr
+++ b/content/blog/understanding-zeitgeist-ai-code-review/contents.lr
@@ -14,7 +14,7 @@ One warning, and a promise. The worry has a name now, and the people working on 
 
 These aren't graded, and the cards won't tell you if you're right. Pick your honest answer for each, notice your assumptions, then read on. The survey revisits every one.
 
-<iframe src="before-you-read.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="before-you-read.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Hold your answers. Let's see where the field has landed.
 
@@ -36,7 +36,7 @@ The diagnosis bites hardest at the pull request, because that's the moment the t
 
 Here is what that looks like in practice: a clean diff, and the five checks a reviewer actually has to run.
 
-<iframe src="ai-pr-no-smell.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="ai-pr-no-smell.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 Every checklist I read hits the same failure modes. [GitHub's engineering team](https://github.blog/ai-and-ml/generative-ai/agent-pull-requests-are-everywhere-heres-how-to-review-them/) published guidance in May 2026 built around the insight that agents optimize for surface plausibility, not semantic correctness. Their data is striking: GitHub Copilot code review has processed over 60 million reviews, more than one in five code reviews on GitHub now involve an agent, and a January 2026 study found agent-generated code introduces more redundancy and quiet debt per change than human-written code. The playbook targets the specific ways agents slip: gaming CI to go green, reimplementing utilities that already exist, hallucinating imports that resolve to the wrong symbol, and writing tests that pass without verifying anything.
 
@@ -70,7 +70,7 @@ If understanding is the bottleneck, how do we cross it faster? Litt's move is to
 
 Toggle between the two for the same change:
 
-<iframe src="literate-diff.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="literate-diff.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 This is where reviewing big PRs with agents pays off most, since the bigger the change, the more the raw diff fails and the explainer earns its keep. Nested inside every explainer is a second device Litt borrowed from Andy Matuschak: a five-question quiz you answer before you approve. His rule is one I've adopted wholesale; he won't send code to a teammate until he can pass the quiz, and he does the same when he reviews theirs. The agent loop runs faster than the speed of human understanding, and the quiz is the mechanical brake that asks whether you actually get it. (This post is my own attempt at that brake; the widget at the end is the quiz, built from [Matuschak's argument](https://andymatuschak.org/books/) that "books don't work" and the spaced-repetition pattern he and Nielsen embedded in Quantum Country.)
 
@@ -108,7 +108,7 @@ Read down the table and you can see the conversation's shape: a diagnosis (under
 
 Here's the quiz. Five cards, instant feedback, and a live score. This is the speed-regulator technique, turned back on the post itself.
 
-<iframe src="check-understanding.html" width="100%" scrolling="no" style="border: 1px solid #ddd; border-radius: 6px;" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
+<iframe src="check-understanding.html" width="100%" scrolling="no" onload="this.style.height=this.contentDocument.body.scrollHeight+'px'"></iframe>
 
 If you missed any, that's the spot where your mental model and the field's are still diverging, and it's exactly where cognitive debt would quietly accrue. Ask, find the gap, close it, and ask again. That loop is the whole point.
 ---

--- a/content/blog/wicked-python-trickery-dynamically-patch-a-python-functions-source-code-at-runtime/contents.lr
+++ b/content/blog/wicked-python-trickery-dynamically-patch-a-python-functions-source-code-at-runtime/contents.lr
@@ -263,7 +263,7 @@ So the writing on the wall is that I'd have to write one tool for every possible
 
 Further more, inspired by the Marimo blog post, `ToolBot` is designed to just do the tool picking, delegating the execution and return of the broader LLM-powered Python program back to the developer. In this way, I can give myself more flexibility when building entire "Agentic" programs, more so than if I were to use `AgentBot` in its current form. It allowed me to build a more powerful version of a tool-calling agent using `ToolBot` with generative UIs in a Marimo notebook. For this, it's easier to demo via a screencast instead of by me describing it in prose:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/tk5wvb556f8?si=sXSRulZ2ooBplapr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tk5wvb556f8?si=sXSRulZ2ooBplapr" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 And if you're curious to try running it, you can run it with the following command:
 

--- a/content/projects/flu-forecaster/contents.lr
+++ b/content/projects/flu-forecaster/contents.lr
@@ -5,7 +5,7 @@ body:
 #### description ####
 text:
 
-<iframe src="https://docs.google.com/presentation/d/1GHSUZHxxEATvhhffTnpjJIoKW65ZJ0NeQ3M4hh_fYzI/embed?start=false&loop=false&delayms=10000" frameborder="0" width="480" height="299" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<iframe src="https://docs.google.com/presentation/d/1GHSUZHxxEATvhhffTnpjJIoKW65ZJ0NeQ3M4hh_fYzI/embed?start=false&loop=false&delayms=10000" width="480" height="299" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 
 As part of my Insight project, I built Flu Forecaster,
 a project that aims to forecast influenza sequence evolution using deep learning.

--- a/templates/blocks/youtube.html
+++ b/templates/blocks/youtube.html
@@ -5,6 +5,5 @@
   <iframe
     style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
     src="https://www.youtube.com/embed/{{ url.split('=')[1] }}"
-    frameborder="0"
     allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
## What

The visible frame around embedded iframe widgets was getting irritating, and border control was scattered as per-embed inline styling across many posts.

## Change

- Add a single site-wide rule to `assets/static/css/custom.css`:
  ```css
  iframe { border: none; }
  ```
  Every existing and future iframe now renders flush with the page, no per-embed styling required.

- Remove now-redundant local customizations across 18 files:
  - `style="border: 1px solid #ddd; border-radius: 6px;"` (the actual visible frames) from 3 posts
  - `style="border: none;"` from 4 posts
  - legacy `frameborder="0"` attributes from `templates/blocks/youtube.html` and 11 embeds (YouTube, LinkedIn, figshare, Google Slides)

## Notes

- Non-border styling preserved (e.g. the centering `style` on the Moderna YouTube embed, and all `onload` height-sizing handlers).
- Verified: zero `frameborder` attributes and zero inline `border` styles remain on any `<iframe>`.
- Chose a plain rule over `!important` since all inline border styles are gone; happy to harden it if preferred.