### PR TITLE
fix(blog): rename to Quantum Computing for the Probabilistic Bayesian

### DIFF
--- a/content/blog/quantum-ml-for-the-probabilistic-bayesian/contents.lr
+++ b/content/blog/quantum-ml-for-the-probabilistic-bayesian/contents.lr
@@ -1,4 +1,4 @@
-title: Quantum ML, for the Probabilistic Bayesian
+title: Quantum Computing for the Probabilistic Bayesian
 ---
 author: Eric J. Ma
 ---


### PR DESCRIPTION
One-line title fix: drop misleading 'ML', replace with 'Computing'.