### PR TITLE
blog: link AI_POLICY.md to community policy list [2026-07-20]

### DIFF
--- a/content/blog/choose-your-own-ai-policy/contents.lr
+++ b/content/blog/choose-your-own-ai-policy/contents.lr
@@ -31,7 +31,7 @@ The first flavor is what I want more of. A contributor who uses an agent to enga
 
 ## Write your stance down
 
-The heart of Henry's PR is `AI_POLICY.md`, a project-level file that tells contributors what you expect. The PR sketches three tiers you can adapt.
+The heart of Henry's PR is `AI_POLICY.md`, a project-level file that tells contributors what you expect. The PR sketches three tiers you can adapt, and a [community-maintained list of real policies](https://github.com/melissawm/open-source-ai-contribution-policies) from dozens of projects shows what other maintainers have chosen.
 
 **All in.** AI-assisted contributions are welcome on the same footing as any other, as long as they meet your quality bar and are disclosed.
 


### PR DESCRIPTION
## What

The "Choose your own AI policy" post mentions `AI_POLICY.md` three times but never links to where a reader can find real-world examples. A reader who wants to see actual policies has to dig through cookie PR #821 to find them, which is the rathole that led to melissawm/open-source-ai-contribution-policies.

## Fix

Added one inline link on the first mention of `AI_POLICY.md` (line 34) pointing to [melissawm/open-source-ai-contribution-policies](https://github.com/melissawm/open-source-ai-contribution-policies), a community-maintained table of 100+ real AI contribution policies across open source projects (CPython, Django, curl, Ghostty, NumPy, etc.). This is the same resource the cookie guide itself references as `[ai-policy-list]`.

The cookie PR #821 link in the post is unchanged (merged, works fine). This just closes the gap so readers can find examples without leaving the post.