### PR TITLE
talks: add agentic data science talks, spruce up all talk descriptions

### DIFF
--- a/content/talks/agentic-data-science-live-bayesian-modeling-data-driven-pharma-2026/contents.lr
+++ b/content/talks/agentic-data-science-live-bayesian-modeling-data-driven-pharma-2026/contents.lr
@@ -1,0 +1,23 @@
+title: Agentic Data Science: Live Bayesian Modeling with Marimo & Coding Agents | Data Driven Pharma East 2026
+---
+body:
+
+#### youtube ####
+url: https://www.youtube.com/watch?v=Ol5t2Q2bZwU
+
+#### description ####
+
+text: Live demo recorded at Data Driven Pharma East 2026 in Boston. I pair-programmed with a coding agent (Cursor + Composer 2.5) inside a Marimo notebook to build a Bayesian hierarchical model of protein melting points in real time. We load and explore protein meltome data, build a four-parameter logistic (4PL) curve with PyMC, estimate melting temperatures with full uncertainty quantification, expand to a hierarchical model across yeast proteins, and rank proteins by thermal stability. Along the way I share lessons on when to go fast versus slow down with coding agents, sequential versus parallel exploration, data provenance and reproducibility, and model cost considerations.
+
+---
+_model: project
+---
+summary: Pair-programming with a coding agent inside a Marimo notebook to build a Bayesian hierarchical model of protein melting points, live.
+---
+pub_date: 2026-06-12
+---
+category: Work
+---
+visible:
+
+Visible

--- a/content/talks/agentic-data-science-marimo-notebooks-festival-of-genomics-2026/contents.lr
+++ b/content/talks/agentic-data-science-marimo-notebooks-festival-of-genomics-2026/contents.lr
@@ -1,0 +1,23 @@
+title: Agentic Data Science with Marimo Notebooks | Festival of Genomics 2026
+---
+body:
+
+#### youtube ####
+url: https://www.youtube.com/watch?v=SbpkwDF01MM
+
+#### description ####
+
+text: Workshop live demo at Festival of Genomics 2026 on using coding agents inside Marimo notebooks as an agentic data science workflow. We start with setup from the workshop GitHub repo, installing prerequisites like a coding agent and uv, and launching the demo Marimo notebook. Then I connect an agent to the live notebook session using the marimo_pair skill, load two protein engineering datasets (activity and enantioselectivity) from ACS Catalysis, and do exploratory analysis with interactive Plotly visuals, including scatter plots with median lines and position-by-mutation heatmaps. Finally, I build a 3Dmol.js AnyWidget to load PDB 7OG3 and color protein residues by the selected metric, then transition into hands-on hack mode with your own or suggested datasets.
+
+---
+_model: project
+---
+summary: A hands-on Festival of Genomics 2026 workshop on coding agents inside Marimo notebooks, with live protein data analysis and 3D structure visualization.
+---
+pub_date: 2026-06-08
+---
+category: Work
+---
+visible:
+
+Visible

--- a/content/talks/agentic-data-science-with-marimo-pair/contents.lr
+++ b/content/talks/agentic-data-science-with-marimo-pair/contents.lr
@@ -1,0 +1,23 @@
+title: Agentic Data Science with Marimo Pair
+---
+body:
+
+#### youtube ####
+url: https://www.youtube.com/watch?v=DvSxrCcfWFs
+
+#### description ####
+
+text: In this live demo, I show how to use Marimo notebooks with Cursor and Marimo Pair for agentic exploratory data analysis, with Marimo as the analysis canvas and Cursor as the coding agent that can manipulate a live Python kernel. I walk through setup from my GitHub repo, start a Marimo server in sandbox mode, and load two protein engineering datasets (activity/conversion and chiral selectivity) into Polars. We build an interactive Plotly scatter plot for single-point mutations, dropdown-controlled line charts comparing mean vs. max mutational effects by position, and an anywidget 3Dmol.js viewer that maps residue-level effects onto the protein ribbon. The key observation: beneficial mutations are often distal to the active site.
+
+---
+_model: project
+---
+summary: Marimo as the analysis canvas and Cursor as the coding agent: live notebook EDA and 3D protein visualization.
+---
+pub_date: 2026-05-14
+---
+category: Work
+---
+visible:
+
+Visible

--- a/content/talks/an-attempt-at-demystifying-bayesian-deep-learning/contents.lr
+++ b/content/talks/an-attempt-at-demystifying-bayesian-deep-learning/contents.lr
@@ -7,13 +7,13 @@ resource: Slides
 body:
 
 #### description ####
-text: At PyData NYC 2017, I presented a talk on the intuition behind Deep Learning (DL) and Bayesian DL, using mostly pictures and code, and with as little math as possible.
+text: Deep learning is, at its core, matrix multiplications with weights learned by gradient descent. Bayesian deep learning is what you get when you put priors on those weights. That's the whole mystery! In this PyData NYC 2017 talk, I build the intuition with mostly pictures and PyMC3/Theano code, with as little math as possible, and show how to construct Bayesian neural networks and visualize the uncertainty in their predictions.
 #### youtube ####
 url: https://www.youtube.com/watch?v=s0S6HFdPtlA
 #### slides ####
 url: http://ericmjl.github.io/bayesian-deep-learning-demystified
 ---
-summary: In which I tell you why Bayesian deep learning is nothing really special, delivered at PyData NYC 2017.
+summary: In which I show that Bayesian deep learning is nothing special: priors on the weights, explained with pictures and PyMC3 code.
 ---
 category: Grad School
 ---

--- a/content/talks/an-attempt-at-demystifying-graph-deep-learning/contents.lr
+++ b/content/talks/an-attempt-at-demystifying-graph-deep-learning/contents.lr
@@ -4,6 +4,8 @@ body:
 
 #### youtube ####
 url: https://youtu.be/cSN-DqPJzY0
+#### description ####
+text: Graph deep learning sounds exotic, but the core ideas are picture-friendly. This talk follows four parts: how graphs can be represented as arrays, what message passing is (and its linear algebra interpretation), how embedding message passing inside a neural network gives you message passing neural networks, with graph Laplacian and graph attention networks as variations on a theme, and the learning tasks that involve graphs, such as node label prediction and edge prediction. Lots of pictures, a minimum number of equations. If you've used neural networks but never built a graph neural network, you'll leave ready to implement your own GNN layers instead of relying on black box APIs.
 #### slides ####
 url: https://ericmjl.github.io/graph-deep-learning-demystified/#/title-slide
 #### github ####
@@ -13,7 +15,7 @@ category: Work
 ---
 lead: Yes
 ---
-summary: In this talk, inspired by my 2017 attempt at demystifying Bayesian deep learning, I now attempt to demystify graph deep learning.
+summary: Graphs as arrays, message passing, and how they add up to message passing neural networks, explained with lots of pictures and a minimum number of equations.
 ---
 pub_date: 2022-01-08
 ---

--- a/content/talks/bayesian-statistical-analysis-with-pymc3/contents.lr
+++ b/content/talks/bayesian-statistical-analysis-with-pymc3/contents.lr
@@ -3,13 +3,13 @@ title: Bayesian Statistical Analysis with Python | PyCon 2017
 body:
 
 #### description ####
-text: At PyCon 2017, I illustrate, using four statistical analysis problems, how to do parameter estimation and case/control comparison (A/B testing) with PyMC3 code.
+text: You've got data, and now you want to analyze it with Python. Do you do the t-test? The chi-squared test? How do you decide? In this PyCon 2017 talk, I show you how to take common statistical decision problems, formulate them as Bayesian estimation problems, and use PyMC3 as the workhorse. Four worked examples cover parameter estimation and case/control (A/B) comparisons. The talk is math-light and code-heavy, and the accompanying notebooks give you a template for your own Bayesian analyses.
 #### youtube ####
 url: https://www.youtube.com/watch?v=p1IB4zWq9C8
 #### notebooks ####
 url: https://github.com/ericmjl/bayesian-stats-talk
 ---
-summary: How to do parameter estimation and case/control comparison in PyMC3, delivered at PyCon 2017.
+summary: Turn "which statistical test do I use?" into Bayesian estimation problems, with PyMC3 as the workhorse.
 ---
 category: Grad School
 ---

--- a/content/talks/beyond-two-groups-generalized-abcde-testing/contents.lr
+++ b/content/talks/beyond-two-groups-generalized-abcde-testing/contents.lr
@@ -3,15 +3,13 @@ title: Beyond Two Groups: Generalized A/B[/C/D/E...] Testing | PyCon 2019
 body:
 
 #### description ####
-text:
-
-At PyCon 2019, I delivered my rant against canned statistical procedures (and more generally, canned modelling), showing cases where one might use the t-test but run into wrong inferences as a result.
+text: Bayesian A/B testing has gained popularity over the years, but the examples always seem to stop at two groups. Shouldn't we be able to compare three, four, five groups? In this PyCon 2019 talk, I use life-like simulated examples, inspired by my work and by meeting others at conferences, to generalize A/B testing beyond rigid two-group, case/control comparisons: Bayesian estimation on website click data, and 4-parameter dose-response curves. The natural extension turns out to be plain Bayesian estimation: with a probabilistic programming language like PyMC3, going beyond two groups is trivial, and you get to think in terms of the generative model for your data. There's plenty of code from the modern PyData stack, including PyMC3, pandas, and HoloViews.
 #### youtube ####
 url: https://www.youtube.com/watch?v=Pt37qA351yk
 #### slides ####
 url: https://ericmjl.github.io/bayesian-generalized-abcde-testing
 ---
-summary: My rant against canned statistical procedures, delivered at PyCon 2019.
+summary: My PyCon 2019 rant against canned statistical procedures, and how Bayesian estimation with PyMC3 extends A/B testing beyond two groups.
 ---
 category: Work
 ---

--- a/content/talks/computational-biology-in-bioengineering/contents.lr
+++ b/content/talks/computational-biology-in-bioengineering/contents.lr
@@ -5,13 +5,13 @@ body:
 #### youtube ####
 url: https://youtu.be/jcqYY8ymL8M
 #### description ####
-text: A virtual fireside chat in which I describe how computational biology, in its multiple forms, shows up in the discipline we call biological engineering.
+text: A virtual fireside chat with UBC's MICB 448S (Introduction to Biological Machines) seminar. I trace my journey from UBC integrated sciences and the founding days of UBC iGEM, through my ScD in MIT Biological Engineering, to industry data science, and describe how computational biology shows up in biological engineering along the way: network science, deep learning, and Bayesian methods applied to biological problems.
 ---
 category: Work
 ---
 lead: Yes
 ---
-summary: Virtual fireside chat about how computational biology shows up in Bioengineering.
+summary: From UBC iGEM to MIT to industry: how network science, deep learning, and Bayesian methods show up in biological engineering.
 ---
 pub_date: 2022-04-05
 ---

--- a/content/talks/ensuring-reproducibility-with-pixi-a-live-demo-and-discussion/contents.lr
+++ b/content/talks/ensuring-reproducibility-with-pixi-a-live-demo-and-discussion/contents.lr
@@ -4,12 +4,14 @@ body:
 
 #### youtube ####
 url: https://www.youtube.com/watch?v=EQgklFqumGI
+#### description ####
+text: Reproducibility matters across science, data science, ML, and AI, and Pixi helps keep environments consistent. In this live demo and discussion with Hugo Bowne-Anderson, we clone the LlamaBot project, configure multiple environments, and run JupyterLab and documentation builds on the back of Pixi's lock file functionality. We also explore containerization, creating and running CUDA-enabled environments inside Docker containers with Pixi, and real-world use cases that show why this all matters.
 ---
 category: Work
 ---
 lead: No
 ---
-summary: In this video, Hugo Bowne-Anderson and I chat about the revolutionary package manager Pixi. We discuss myexperiences with Pixi, emphasizing its advantages in package management, reproducibility, and collaboration within data science teams. Key topics include the benefits of lock files, simplifying Docker and GPU environments, and the impact of Pixi on reproducibility and developer efficiency.
+summary: A live demo with Hugo Bowne-Anderson: Pixi lock files, multi-environment workflows, and CUDA-enabled Docker containers for reproducible data science.
 ---
 pub_date: 2024-10-01
 ---

--- a/content/talks/how-software-skillsets-will-accelerate-your-data-science-work/contents.lr
+++ b/content/talks/how-software-skillsets-will-accelerate-your-data-science-work/contents.lr
@@ -5,7 +5,7 @@ body:
 #### youtube ####
 url: https://youtu.be/7NEQApSLT1U
 #### description ####
-text: In this talk at the University of Maryland Baltimore County's Masters of Data Science program, I share with students and faculty how software development skillsets accelerate a data scientist's ability to deliver on projects.
+text: Data science is no longer solo work, but teamwork, and discipline is what enables better collaborative work. In this UMBC Data Science Speaker Series talk, I share how software development skillsets accelerate a data scientist's ability to deliver: standardized project templates, version control for code and data, testing with pytest and pandera, portable environments with containers, and documentation that lets any teammate jump onto any project. Everything is drawn from lessons at work.
 #### slides ####
 url: https://hackmd.io/@ericmjl/software-ds
 ---
@@ -13,7 +13,7 @@ category: Work
 ---
 lead: Yes
 ---
-summary: Me explaining exactly what I state in the title!👆
+summary: Standardize, test, document, and version: software skills that turn data science from solo work into teamwork.
 ---
 pub_date: 2022-05-02
 ---

--- a/content/talks/modern-principled-data-science-workflow/contents.lr
+++ b/content/talks/modern-principled-data-science-workflow/contents.lr
@@ -3,7 +3,7 @@ title: Modern, Principled Data Science Workflow | PyData Boston 2020
 body:
 
 #### description ####
-text: In this talk, I share five key principles, learned from the software development world, that help accelerate data science project development and amplify impact.
+text: Data scientists can borrow a lot from software engineers. In this PyData Boston 2020 meetup talk, I share five key principles, learned from the software development world, that help accelerate data science project development and amplify impact.
 #### slides ####
 url: https://ericmjl.github.io/principled-ds-workflow/
 #### github ####
@@ -13,7 +13,7 @@ url: https://www.youtube.com/watch?v=Dx2vG6qmtPs
 ---
 category: Work
 ---
-summary: In this talk, I share five key principles, learned from the software development world, that help accelerate data science project development and amplify impact.
+summary: Five principles borrowed from software development that accelerate data science projects and amplify their impact.
 ---
 pub_date: 2020-07-23
 ---

--- a/content/talks/networks-networks-everywhere/contents.lr
+++ b/content/talks/networks-networks-everywhere/contents.lr
@@ -3,13 +3,13 @@ title: Networks, Networks Everywhere | Big Data Boston 2016
 body:
 
 #### description ####
-text: In this talk, I describe how networks and their applications are ubiquitous, and can be used to solve problems that are otherwise difficult to reason about.
+text: Networks are everywhere in the world around us. In this presentation hosted by DataCamp at their Big Data Boston meetup, I describe how networks and their applications are ubiquitous, and how representing a problem as a graph lets you solve ones that are otherwise difficult to reason about. If this talk sparks ideas, my Network Analysis in Python course on DataCamp goes deeper.
 #### youtube ####
 url: https://www.youtube.com/watch?v=TuaAlpfTeZs
 #### slides ####
 url: https://ericmjl.github.io/big-data-boston-2016/
 ---
-summary: The many places that graphs can be found, delivered at Big Data Boston 2016 and hosted by DataCamp.
+summary: Networks are everywhere, and representing problems as graphs unlocks ones that are otherwise hard to reason about.
 ---
 category: Grad School
 ---

--- a/content/talks/productive-patterns-for-agent-assisted-programming-pydata-boston-2025/contents.lr
+++ b/content/talks/productive-patterns-for-agent-assisted-programming-pydata-boston-2025/contents.lr
@@ -5,15 +5,15 @@ body:
 #### youtube ####
 url: https://www.youtube.com/watch?v=XXR2_pYGNgs
 #### description ####
-text: Live stream for my PyData Boston 2025 talk on Productive Patterns for Agent-Assisted Programming.
+text: Live stream recording from the PyData Boston meetup.
 #### youtube ####
 url: https://www.youtube.com/watch?v=YuA_9x1aSZ4
 #### description ####
-text: Official PyData channel recording.
+text: You're already using AI coding assistants for more than autocomplete, but are you using them effectively? This PyData Boston 2025 talk presents battle-tested patterns for productive collaboration with AI coding agents on real Python projects. You'll learn a structured four-step loop: plan your changes, write tests first, let the agent build, then document what you created, iterating through the cycle. We also cover why fast test harnesses are critical for agent productivity, how to pipe shell tools and logging output back to your agent for better context, and how custom slash-commands automate repetitive tasks like code cleanup and style enforcement.
 ---
 _model: project
 ---
-summary: Productive Patterns for Agent-Assisted Programming
+summary: Battle-tested patterns for AI coding agents: plan, write tests first, let the agent build, document, and repeat.
 ---
 pub_date: 2025-12-10
 ---

--- a/content/talks/software-testing-in-open-source-and-data-science/contents.lr
+++ b/content/talks/software-testing-in-open-source-and-data-science/contents.lr
@@ -4,12 +4,14 @@ body:
 
 #### youtube ####
 url: https://www.youtube.com/watch?v=bJGgVoV4GTc
+#### description ####
+text: Test your work! In this Data Umbrella talk, I cover why software testing matters for open source and for data science: correctness, reliability, and contracts against future breakage. We walk through what a test looks like, how to automate tests, the kinds of tests that exist (unit, execution, integration), and how testing changes when the subject is ML model code, data validation, or pipeline code. I also share a case study from my daily work and how to navigate the tradeoff between immediate velocity and long-term productivity.
 ---
 category: Work
 ---
 lead: Yes
 ---
-summary: In which I talk about how software testing is awesome for open source and data science.
+summary: Testing your code, your data, and your pipelines: why software testing matters for open source and data science.
 ---
 pub_date: 2022-08-30
 ---

--- a/content/talks/testing-for-data-scientists/contents.lr
+++ b/content/talks/testing-for-data-scientists/contents.lr
@@ -3,15 +3,15 @@ title: Testing for Data Scientists | PyData Ann Arbor 2020
 body:
 
 #### description ####
-text: In this talk, I use two examples to illustrate how testing can be better incorporated into a data scientist's workflow. At the same time, I also introduce two libraries, [Hypothesis](hypothesis.readthedocs.io) and [Great Expectations](https://greatexpectations.io/), which can help with testing code and data.
+text: Code written in a programming language is the most flexible way to accomplish your data science work, and every line we write is technical debt. In this PyData Ann Arbor talk, I use two worked examples to show how testing fits into a data scientist's workflow, and introduce two libraries that help: [Hypothesis](https://hypothesis.readthedocs.io/) for property-based testing of your code, and [Great Expectations](https://greatexpectations.io/) for validating your data. You'll leave with a practical sense of which tests to write and when.
 #### slides ####
 url: https://ericmjl.github.io/testing-for-data-scientists/
 #### youtube ####
-url: https://www.youtube.com/v=5RKuHvZERLY
+url: https://www.youtube.com/watch?v=5RKuHvZERLY
 ---
 category: Work
 ---
-summary: How data scientists can incorporate testing into their development, delivered at PyData Ann Arbor in Jan 2020.
+summary: How data scientists can incorporate testing into their workflow, with Hypothesis for code and Great Expectations for data.
 ---
 visible: Visible
 ---


### PR DESCRIPTION
## What

Two related updates to the `/talks/` page:

### 1. Add 3 new talks (from the [@ericmjl YouTube channel](https://www.youtube.com/@ericmjl))

- **Agentic Data Science with Marimo Notebooks | Festival of Genomics 2026** (34 min, pub 2026-06-08)
- **Agentic Data Science: Live Bayesian Modeling with Marimo & Coding Agents | Data Driven Pharma East 2026** (27 min, pub 2026-06-12)
- **Agentic Data Science with Marimo Pair** (20 min live demo, pub 2026-05-14)

Skipped per review: thesis defense, short-form videos, tutorial series. Duplicate check confirmed none of these video IDs existed in `content/talks/` or `content/teaching/`.

### 2. Spruce up descriptions + summaries for the 12 pre-existing talks

Each rewrite pulls topic detail from the video's actual YouTube description (fetched via yt-dlp) so search and readers get concrete content: covered libraries, talk structure, and takeaways. Also:

- Added missing `description` blocks to the 3 talks that had none (Graph DL, Pixi, Data Umbrella testing)
- Fixed malformed YouTube URL on Testing for Data Scientists (`/v=` -> `/watch?v=`)
- Fixed "myexperiences" typo in the Pixi summary
- Card summaries now carry keywords instead of duplicating the description verbatim

## Verification

- `pixi run build` passes; talks count 17 -> 20