### PR TITLE
blogbot: Substack terminal fallback docs + freetext banner script

### DIFF
--- a/.agents/skills/blogbot/SKILL.md
+++ b/.agents/skills/blogbot/SKILL.md
@@ -445,6 +445,25 @@ Then hand the user the Title and Subtitle as plain text for the separate
 fields; they paste the clipboard into the body and save/publish by hand. The
 banner URL is the LIVE logo.webp, so the post must be merged + URL-200 first.
 
+### TERMINAL FALLBACK when Substack rejects the formatted paste: plain text + manual punch-list
+
+2026-08-21: the HTML-flavor clipboard paste was REJECTED by the Substack editor
+mid-edit ("substack isn't allowing that either!") while patching new paragraphs
+(Terrana) into an already-formatted post. When the editor refuses the formatted
+paste, do NOT iterate more clipboard formats — drop straight to the terminal
+fallback:
+
+1. pbcopy the content as PLAIN TEXT (no HTML, no markdown; report word count).
+2. Give a short manual-formatting punch-list: exactly which phrases to bold,
+   which phrase(s) to hyperlink and to where, and the insertion point
+   (e.g. "goes after the Ormoni paragraph").
+3. Include the knock-on consistency edits (intro counts, closer geographic
+   claims, subtitle) so the manual patch does not silently falsify the post.
+
+Eric accepted this fallback without friction and finished the post by hand; his
+frustration attaches to repeated failed format attempts, not to doing two or
+three bold/link touches himself.
+
 SUBSTACK POST TYPES — know the difference:
 - "notes" = short-form (tweet-like, shown in the Substack feed). The "New post"
   button in the Substack nav opens a NOTE composer, NOT the long-form editor.

--- a/.agents/skills/blogbot/scripts/banner_freetext.py
+++ b/.agents/skills/blogbot/scripts/banner_freetext.py
@@ -1,0 +1,68 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "llamabot",
+#   "pydantic",
+#   "rich",
+#   "pillow",
+#   "openai",
+#   "requests",
+#   "python-dotenv",
+# ]
+# ///
+"""Generate a DALL-E banner for the Substack jobs post from raw text (no slug).
+
+Adapts blogbot's banner.py to take free text instead of a contents.lr slug,
+and writes the image to ~/Downloads.
+"""
+
+import sys
+from io import BytesIO
+from pathlib import Path
+
+from dotenv import load_dotenv
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).parent))
+from banner import DallEImagePrompt, dalle_sysprompt  # noqa: E402
+from llamabot import StructuredBot  # noqa: E402
+
+load_dotenv(Path.home() / "github/website/.env")
+
+import os  # noqa: E402
+import sys  # noqa: E402
+
+os.environ.setdefault("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", ""))
+sys.path.insert(0, str(Path.home() / "github/website"))
+
+from apis.blogbot.images import generate_banner_image_bytes  # noqa: E402
+
+
+def save_image_as_webp(image_bytes: bytes, output_path: Path) -> None:
+    img = Image.open(BytesIO(image_bytes))
+    if img.mode in ("RGBA", "LA", "P"):
+        rgb = Image.new("RGB", img.size, (255, 255, 255))
+        if img.mode == "P":
+            img = img.convert("RGBA")
+        rgb.paste(img, mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None)
+        img = rgb
+    elif img.mode != "RGB":
+        img = img.convert("RGB")
+    img.save(output_path, "WEBP", quality=95)
+
+
+def main():
+    text = Path(sys.argv[1]).read_text()
+    bot = StructuredBot(
+        dalle_sysprompt(), model="gpt-4.1", pydantic_model=DallEImagePrompt
+    )
+    prompt = bot(text).content
+    print("PROMPT:", prompt[:300])
+    image_bytes = generate_banner_image_bytes(prompt)
+    out = Path.home() / "Downloads" / "substack-jobs-banner.webp"
+    save_image_as_webp(image_bytes, out)
+    print("SAVED:", out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- **docs(blogbot)**: document the terminal fallback when the Substack editor rejects formatted clipboard pastes (plain-text pbcopy + manual formatting punch-list, including knock-on consistency edits).
- **feat(blogbot)**: add `scripts/banner_freetext.py`, an adaption of banner.py that generates a DALL-E banner from raw text (no contents.lr slug) and saves it to ~/Downloads. Dependencies use PEP 723 inline metadata; ruff-clean.