### PR TITLE
chore(opencode): remove project-level buffer MCP config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,15 +1,3 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "buffer": {
-      "type": "remote",
-      "url": "https://mcp.buffer.com/mcp",
-      "oauth": false,
-      "enabled": true,
-      "headers": {
-        "Authorization": "Bearer {env:BUFFER_API_KEY}"
-      },
-      "timeout": 10000
-    }
-  }
+  "$schema": "https://opencode.ai/config.json"
 }


### PR DESCRIPTION
## What

Removes the buffer MCP server entry from the project `opencode.json`. Buffer MCP is now connected via the global opencode config (OAuth-based), so the project-level entry (env API key header) is redundant.

Verified buffer MCP is present in `~/.config/opencode/opencode.json` before removal.