### PR TITLE
talks: add Canvas Chat talk (SciPy 2026) [2026-09-01]

### DIFF
--- a/content/talks/canvas-chat-non-linear-workflows-for-ai-assisted-data-science-scipy-2026/contents.lr
+++ b/content/talks/canvas-chat-non-linear-workflows-for-ai-assisted-data-science-scipy-2026/contents.lr
@@ -1,0 +1,23 @@
+title: Canvas Chat: non-linear workflows for AI-assisted data science | SciPy 2026
+---
+body:
+
+#### youtube ####
+url: https://www.youtube.com/watch?v=V42Hq61JgcY
+
+#### description ####
+
+text: Talk recorded at SciPy 2026 on Canvas Chat, a browser-based tool that combines Python's data science stack with LLM connectivity for natural language interaction with data. Built on Pyodide, it runs entirely in the browser with no server-side computation required; you bring your own API keys for LLM access, while all session data persists locally in IndexedDB. The visual, non-linear interface represents conversations as nodes on an infinite canvas, supporting branching, merging, and stateful exploration of data analysis workflows. The talk shows how browser-based Python plus LLMs can democratize data science by removing infrastructure barriers while preserving privacy and reproducibility.
+
+---
+_model: project
+---
+summary: A SciPy 2026 talk on Canvas Chat, a browser-based tool for non-linear, visual AI-assisted data analysis with Python and LLMs.
+---
+pub_date: 2026-09-01
+---
+category: Work
+---
+visible:
+
+Visible


### PR DESCRIPTION
Adds the Canvas Chat talk from SciPy 2026 to the talks page.

- Video: https://www.youtube.com/watch?v=V42Hq61JgcY
- Title: Canvas Chat: non-linear workflows for AI-assisted data science | SciPy 2026
- pub_date: 2026-09-01 (YouTube upload date)
- Slug: `canvas-chat-non-linear-workflows-for-ai-assisted-data-science-scipy-2026`